### PR TITLE
DEVEXP-256: Add timezone response plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
    ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/sinch/sinch-sdk-node/run_tests.yaml?branch=main)
    [![Node.js LTS](https://img.shields.io/badge/Node.js-LTS%20supported-brightgreen)](https://nodejs.org/en/download/)
    ![Latest Release](https://img.shields.io/npm/v/@sinch/sdk-core?label=%40sinch%2Fsdk-core&labelColor=FFC658)
-   [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/sinch/sinch-sdk-python/blob/main/LICENSE)
+   [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/sinch/sinch-sdk-node/blob/main/LICENSE)
 
 </h1>
 

--- a/examples/simple-examples/src/voice/calls/get.ts
+++ b/examples/simple-examples/src/voice/calls/get.ts
@@ -30,7 +30,6 @@ import { GetCallResultRequestData, VoiceRegion } from '@sinch/sdk-core';
   const printFormat = getPrintFormat(process.argv);
 
   if (printFormat === 'pretty') {
-    // TODO: Add a post process on the response to fix the missing timezone in the timestamp
     console.log(`The call '${response.callId}' was from '${response.from}' to '${response.to?.endpoint}' and lasted ${response.duration} seconds
     Rate: ${response.userRate?.amount} ${response.userRate?.currencyId} - Debit: ${response.debit?.amount} ${response.debit?.currencyId}`);
   } else {

--- a/packages/sdk-client/src/client/api-fetch-client.ts
+++ b/packages/sdk-client/src/client/api-fetch-client.ts
@@ -1,6 +1,7 @@
 import { ResponsePlugin } from '../plugins/core/response-plugin';
-import { VersionRequest } from '../plugins/version/version.request';
-import { ExceptionResponse } from '../plugins/exception/exception.response';
+import { VersionRequest } from '../plugins/version';
+import { ExceptionResponse } from '../plugins/exception';
+import { TimezoneResponse } from '../plugins/timezone';
 import {
   ApiClient,
   ApiClientOptions,
@@ -34,6 +35,7 @@ export class ApiFetchClient extends ApiClient {
       ...options,
       requestPlugins: [new VersionRequest(), ...(options.requestPlugins || [])],
       responsePlugins: [
+        new TimezoneResponse(),
         new ExceptionResponse(),
         ...(options.responsePlugins || []),
       ],

--- a/packages/sdk-client/src/plugins/exception/readme.md
+++ b/packages/sdk-client/src/plugins/exception/readme.md
@@ -1,7 +1,0 @@
-## Exception
-
-Plugin to trigger an exception in case of wrong response / data based on the response status or custom criteria.
-
-### Type of plugins
-
-- Response plugin: [ExceptionResponse](./exception.response.ts);

--- a/packages/sdk-client/src/plugins/index.ts
+++ b/packages/sdk-client/src/plugins/index.ts
@@ -4,5 +4,6 @@ export * from './basicAuthentication';
 export * from './exception';
 export * from './oauth2';
 export * from './signing';
+export * from './timezone';
 export * from './version';
 export * from './x-timestamp';

--- a/packages/sdk-client/src/plugins/timezone/index.ts
+++ b/packages/sdk-client/src/plugins/timezone/index.ts
@@ -1,0 +1,1 @@
+export * from './timezone.response';

--- a/packages/sdk-client/src/plugins/timezone/timezone.response.ts
+++ b/packages/sdk-client/src/plugins/timezone/timezone.response.ts
@@ -24,7 +24,7 @@ implements ResponsePlugin<V | Record<string, any>> {
               const buggyKey = buggyFields[context.operationId];
               if (key === buggyKey && typeof res[buggyKey] === 'string') {
                 const timestampValue = res[key] as string;
-                const timeZoneRegex = /([+-]\d{2}:?\d{2}|Z)$/;
+                const timeZoneRegex = /([+-]\d{2}(:\d{2})?|Z)$/;
                 if (!timeZoneRegex.test(timestampValue)) {
                   res[key] = timestampValue + 'Z';
                 }

--- a/packages/sdk-client/src/plugins/timezone/timezone.response.ts
+++ b/packages/sdk-client/src/plugins/timezone/timezone.response.ts
@@ -1,0 +1,40 @@
+import { ResponsePlugin, ResponsePluginContext } from '../core/response-plugin';
+import { PluginRunner } from '../core';
+
+const buggyOperationIds: string[] = [
+  'GetCallResult',
+];
+
+const buggyFields: Record<string, string>  = {
+  'GetCallResult': 'timestamp',
+};
+
+export class TimezoneResponse<V extends Record<string, any> | undefined = Record<string, any>>
+implements ResponsePlugin<V | Record<string, any>> {
+
+  public load(
+    context: ResponsePluginContext,
+  ): PluginRunner<V | Record<string, unknown>, V> {
+    return {
+      transform(res: V) {
+        // HACK to fix a server-side bug: the timestamp is returned without the timezone
+        if (res && buggyOperationIds.includes(context.operationId) ) {
+          for (const key in res) {
+            if (Object.prototype.hasOwnProperty.call(res, key)) {
+              const buggyKey = buggyFields[context.operationId];
+              if (key === buggyKey && typeof res[buggyKey] === 'string') {
+                const timestampValue = res[key] as string;
+                const timeZoneRegex = /([+-]\d{2}:?\d{2}|Z)$/;
+                if (!timeZoneRegex.test(timestampValue)) {
+                  res[key] = timestampValue + 'Z';
+                }
+              }
+            }
+          }
+        }
+        return res;
+      },
+    };
+  }
+
+}

--- a/packages/sdk-client/tests/plugins/timezone/timezone.response.test.ts
+++ b/packages/sdk-client/tests/plugins/timezone/timezone.response.test.ts
@@ -1,0 +1,45 @@
+import { TimezoneResponse } from '../../../src';
+import { ResponsePluginContext } from '../../../src/plugins/core/response-plugin';
+import { Headers } from 'node-fetch';
+
+describe('Timezone response plugin', () => {
+
+  let context: ResponsePluginContext;
+  const TIMESTAMP_WITH_MISSING_TIMEZONE = '2024-01-09T15:50:24.000';
+  const TIMESTAMP_WITH_TIMEZONE = '2024-01-09T15:50:24.000Z';
+
+  beforeEach(() => {
+    context = {
+      operationId: 'GetCallResult',
+      apiName: '',
+      url: '',
+      requestOptions: {
+        headers: new Headers(),
+        basePath: '',
+      },
+    };
+  });
+
+  it('should update the timestamp if the timezone is missing', async () => {
+    const apiResponse = {
+      timestamp: TIMESTAMP_WITH_MISSING_TIMEZONE,
+    };
+    const plugin = new TimezoneResponse();
+    const runner = plugin.load(context);
+    const result = await runner.transform(apiResponse);
+
+    expect(result.timestamp).toBe(TIMESTAMP_WITH_TIMEZONE);
+  });
+
+  it('should NOT update the timestamp if the operationId if not listed', async () => {
+    context.operationId = 'notListedAsBuggy';
+    const apiResponse = {
+      timestamp: TIMESTAMP_WITH_MISSING_TIMEZONE,
+    };
+    const plugin = new TimezoneResponse();
+    const runner = plugin.load(context);
+    const result = await runner.transform(apiResponse);
+
+    expect(result.timestamp).toBe(TIMESTAMP_WITH_MISSING_TIMEZONE);
+  });
+});

--- a/packages/sdk-client/tests/plugins/timezone/timezone.response.test.ts
+++ b/packages/sdk-client/tests/plugins/timezone/timezone.response.test.ts
@@ -7,6 +7,8 @@ describe('Timezone response plugin', () => {
   let context: ResponsePluginContext;
   const TIMESTAMP_WITH_MISSING_TIMEZONE = '2024-01-09T15:50:24.000';
   const TIMESTAMP_WITH_TIMEZONE = '2024-01-09T15:50:24.000Z';
+  const TIMESTAMP_WITH_TIMEZONE_HOURS = '2024-01-09T15:50:24.000+00';
+  const TIMESTAMP_WITH_TIMEZONE_HOURS_MINUTES = '2024-01-09T15:50:24.000+00:00';
 
   beforeEach(() => {
     context = {
@@ -31,7 +33,7 @@ describe('Timezone response plugin', () => {
     expect(result.timestamp).toBe(TIMESTAMP_WITH_TIMEZONE);
   });
 
-  it('should NOT update the timestamp if the timezone is already there', async () => {
+  it('should NOT update the timestamp if the timezone is already there with "Z" format', async () => {
     const apiResponse = {
       timestamp: TIMESTAMP_WITH_TIMEZONE,
     };
@@ -40,6 +42,28 @@ describe('Timezone response plugin', () => {
     const result = await runner.transform(apiResponse);
 
     expect(result.timestamp).toBe(TIMESTAMP_WITH_TIMEZONE);
+  });
+
+  it('should NOT update the timestamp if the timezone is already there with "+XX format"', async () => {
+    const apiResponse = {
+      timestamp: TIMESTAMP_WITH_TIMEZONE_HOURS,
+    };
+    const plugin = new TimezoneResponse();
+    const runner = plugin.load(context);
+    const result = await runner.transform(apiResponse);
+
+    expect(result.timestamp).toBe(TIMESTAMP_WITH_TIMEZONE_HOURS);
+  });
+
+  it('should NOT update the timestamp if the timezone is already there with "+XX:XX format"', async () => {
+    const apiResponse = {
+      timestamp: TIMESTAMP_WITH_TIMEZONE_HOURS_MINUTES,
+    };
+    const plugin = new TimezoneResponse();
+    const runner = plugin.load(context);
+    const result = await runner.transform(apiResponse);
+
+    expect(result.timestamp).toBe(TIMESTAMP_WITH_TIMEZONE_HOURS_MINUTES);
   });
 
   it('should NOT update the timestamp if the operationId if not listed', async () => {

--- a/packages/sdk-client/tests/plugins/timezone/timezone.response.test.ts
+++ b/packages/sdk-client/tests/plugins/timezone/timezone.response.test.ts
@@ -31,6 +31,17 @@ describe('Timezone response plugin', () => {
     expect(result.timestamp).toBe(TIMESTAMP_WITH_TIMEZONE);
   });
 
+  it('should NOT update the timestamp if the timezone is already there', async () => {
+    const apiResponse = {
+      timestamp: TIMESTAMP_WITH_TIMEZONE,
+    };
+    const plugin = new TimezoneResponse();
+    const runner = plugin.load(context);
+    const result = await runner.transform(apiResponse);
+
+    expect(result.timestamp).toBe(TIMESTAMP_WITH_TIMEZONE);
+  });
+
   it('should NOT update the timestamp if the operationId if not listed', async () => {
     context.operationId = 'notListedAsBuggy';
     const apiResponse = {

--- a/packages/voice/src/models/v1/get-call-response-obj/get-call-response-obj.ts
+++ b/packages/voice/src/models/v1/get-call-response-obj/get-call-response-obj.ts
@@ -9,7 +9,7 @@
 export interface GetCallResponseObj {
 
   /** Contains the caller information. */
-  from?: string;
+  from?: GetCallResponseFrom;
   /** Contains the callee information. */
   to?: GetCallResponseTo;
   /** Must be `pstn` for PSTN. */
@@ -27,7 +27,7 @@ export interface GetCallResponseObj {
   /** The date and time of the call. */
   timestamp?: Date;
   /** An object that can be used to pass custom information related to the call. */
-  custom?: object;
+  custom?: string;
   /** The rate per minute that was charged for the call. */
   userRate?: GetCallResponseUserRate;
   /** The total amount charged for the call. */
@@ -37,9 +37,17 @@ export interface GetCallResponseObj {
 export interface GetCallResponseTo {
   /** The type of the destination. */
   type?: string;
-  /** The phone number, user name, or other identifier of the destination. */
+  /** The phone number, username, or other identifier of the destination. */
   endpoint?: string;
 }
+
+export interface GetCallResponseFrom {
+  /** The type of the destination. */
+  type?: string;
+  /** The phone number, username, or other identifier of the destination. */
+  endpoint?: string;
+}
+
 export interface GetCallResponseUserRate {
   /** The currency in which the call is charged. */
   currencyId?: string;

--- a/packages/voice/src/models/v1/get-call-response-obj/index.ts
+++ b/packages/voice/src/models/v1/get-call-response-obj/index.ts
@@ -1,5 +1,6 @@
 export type {
   GetCallResponseObj,
+  GetCallResponseFrom,
   GetCallResponseTo,
   GetCallResponseUserRate,
   GetCallResponseDebit,


### PR DESCRIPTION
This new response plugin is (hopefully) a temporary hack to add the missing timezone (assumption taken it's `Z`) for the API response where it's missing.