### PR TITLE
Provide options for unexploded parameters

### DIFF
--- a/examples/simple-examples/src/numbers/active/list.ts
+++ b/examples/simple-examples/src/numbers/active/list.ts
@@ -21,6 +21,7 @@ const populateActiveNumbersList = (
   const requestData: ListActiveNumbersRequestData = {
     regionCode: 'US',
     type: 'LOCAL',
+    capability: 'SMS',
     pageSize: 2,
   };
 

--- a/examples/simple-examples/src/numbers/available/list.ts
+++ b/examples/simple-examples/src/numbers/available/list.ts
@@ -9,6 +9,7 @@ import { ListAvailableNumbersRequestData } from '@sinch/sdk-core';
   const requestData: ListAvailableNumbersRequestData= {
     regionCode: 'US',
     type: 'LOCAL',
+    capabilities: ['SMS', 'VOICE'],
   };
 
   const sinchClient = initClient();

--- a/packages/numbers/src/rest/v1/active-number/active-number-api.ts
+++ b/packages/numbers/src/rest/v1/active-number/active-number-api.ts
@@ -139,7 +139,9 @@ export class ActiveNumberApi extends NumbersApi {
     const listPromise = buildPageResultPromise<ActiveNumber>(
       this.client,
       requestOptionsPromise,
-      operationProperties);
+      operationProperties,
+      false,
+      ';');
 
     // Add properties to the Promise to offer the possibility to use it as an iterator
     Object.assign(

--- a/packages/numbers/src/rest/v1/active-number/active-number-api.ts
+++ b/packages/numbers/src/rest/v1/active-number/active-number-api.ts
@@ -30,8 +30,8 @@ export interface ListActiveNumbersRequestData {
   'numberPattern.pattern'?: string;
   /** Search pattern to apply. The options are, `START`, `CONTAIN`, and `END`. */
   'numberPattern.searchPattern'?: SearchPatternEnum;
-  /** Number capabilities to filter by, `SMS` and/or `VOICE`. */
-  capability?: Array<CapabilitiesEnum>;
+  /** Number capabilities to filter by, `SMS` or `VOICE`. */
+  capability?: CapabilitiesEnum;
   /** The maximum number of items to return. */
   pageSize?: number;
   /** The next page token value returned from a previous List request, if any. */
@@ -140,8 +140,7 @@ export class ActiveNumberApi extends NumbersApi {
       this.client,
       requestOptionsPromise,
       operationProperties,
-      false,
-      ';');
+    );
 
     // Add properties to the Promise to offer the possibility to use it as an iterator
     Object.assign(

--- a/packages/numbers/src/rest/v1/available-number/available-number-api.ts
+++ b/packages/numbers/src/rest/v1/available-number/available-number-api.ts
@@ -122,7 +122,7 @@ export class AvailableNumberApi extends NumbersApi {
       headers,
       body || undefined,
     );
-    const url = this.client.prepareUrl(requestOptions.basePath, requestOptions.queryParams, false, ';');
+    const url = this.client.prepareUrl(requestOptions.basePath, requestOptions.queryParams, true);
 
     return this.client.processCall<AvailableNumbersResponse>({
       url,

--- a/packages/numbers/src/rest/v1/available-number/available-number-api.ts
+++ b/packages/numbers/src/rest/v1/available-number/available-number-api.ts
@@ -122,7 +122,7 @@ export class AvailableNumberApi extends NumbersApi {
       headers,
       body || undefined,
     );
-    const url = this.client.prepareUrl(requestOptions.basePath, requestOptions.queryParams);
+    const url = this.client.prepareUrl(requestOptions.basePath, requestOptions.queryParams, false, ';');
 
     return this.client.processCall<AvailableNumbersResponse>({
       url,

--- a/packages/sdk-client/src/api/api-client.ts
+++ b/packages/sdk-client/src/api/api-client.ts
@@ -75,9 +75,9 @@ export class ApiClient {
       .reduce(
         (acc, name) => {
           const prop = data[name];
-          acc[name] = typeof prop.toJSON === 'function'
-            ? prop.toJSON()
-            : Array.isArray(prop) ? prop.join(',') : prop.toString();
+          acc[name] = typeof prop.toJSON === 'object'
+            ? JSON.stringify(prop.toJSON())
+            : JSON.stringify(prop);
           return acc;
         },
         {} as { [p in keyof T]: string },
@@ -128,18 +128,16 @@ export class ApiClient {
    * @param {string} url - The base url to be used.
    * @param {Object.<string, string|undefined>} queryParameters - Key-value pair with the parameters. If the value is undefined, the key is dropped.
    * @param {boolean} repeatParamArray - create as many single parameters with each value of the array
-   * @param {string} unexplodedSeparator - the separator to use between values when `explode` is false (default is ',')
    * @return {string} The prepared URL as a string.
    */
   prepareUrl(
     url: string,
     queryParameters: { [key: string]: string | undefined } = {},
     repeatParamArray?: boolean,
-    unexplodedSeparator?: string,
   ): string {
     const queryPart = Object.keys(queryParameters)
       .filter((name) => typeof queryParameters[name] !== 'undefined')
-      .map((name) => this.formatQueryParameter(name, queryParameters, repeatParamArray, unexplodedSeparator))
+      .map((name) => this.formatQueryParameter(name, queryParameters, repeatParamArray))
       .join('&');
 
     const paramsPrefix = url.indexOf('?') > -1 ? '&' : '?';
@@ -152,26 +150,23 @@ export class ApiClient {
    * @param {string} name - The parameter name
    * @param {Object.<string, string|undefined>} queryParameters - Key-value pair with the parameters. If the value is undefined, the key is dropped.
    * @param {boolean}repeatParamArray - Create as many single parameters with each value of the array
-   * @param {string} unexplodedSeparator - the separator to use between values when `explode` is false (default is `,`)
    * @return {string} The query parameter formatted as required by the API
    */
   private formatQueryParameter = (
     name: string,
     queryParameters: { [key: string]: string | undefined } = {},
     repeatParamArray?: boolean,
-    unexplodedSeparator?: string,
   ): string => {
-    const defaultFormat = `${name}=${queryParameters[name]!}`;
-    if(repeatParamArray) {
-      const parameterValue = queryParameters[name];
-      if (parameterValue && parameterValue.indexOf(',') > 0) {
-        const parameterValues = parameterValue.split(',');
-        return parameterValues.map((value) => `${name}=${value}`).join('&');
+    const parameterValue = JSON.parse(queryParameters[name] || '');
+    if (Array.isArray(parameterValue)) {
+      if (repeatParamArray) {
+        return parameterValue.map((value: string) => `${name}=${value}`).join('&');
+      } else {
+        return `${name}=${parameterValue.join(',')}`;
       }
-    } else if (unexplodedSeparator !== undefined) {
-      return defaultFormat.replaceAll(',', unexplodedSeparator);
+    } else {
+      return `${name}=${parameterValue}`;
     }
-    return defaultFormat;
   };
 
   /**

--- a/packages/sdk-client/src/client/api-client-pagination-helper.ts
+++ b/packages/sdk-client/src/client/api-client-pagination-helper.ts
@@ -207,12 +207,11 @@ export const buildPageResultPromise = async  <T>(
   requestOptionsPromise: Promise<RequestOptions>,
   operationProperties: PaginatedApiProperties,
   repeatParamArray?: boolean,
-  unexplodedSeparator?: string,
 ): Promise<PageResult<T>> => {
   // Await the promise in this async method and store the result in client so that they can be reused
   const requestOptions = await requestOptionsPromise;
   const url = client.prepareUrl(
-    requestOptions.basePath, requestOptions.queryParams, repeatParamArray, unexplodedSeparator);
+    requestOptions.basePath, requestOptions.queryParams, repeatParamArray);
 
   return client.processCallWithPagination<T>({
     url,

--- a/packages/sdk-client/src/client/api-client-pagination-helper.ts
+++ b/packages/sdk-client/src/client/api-client-pagination-helper.ts
@@ -206,10 +206,13 @@ export const buildPageResultPromise = async  <T>(
   client: ApiClient,
   requestOptionsPromise: Promise<RequestOptions>,
   operationProperties: PaginatedApiProperties,
+  repeatParamArray?: boolean,
+  unexplodedSeparator?: string,
 ): Promise<PageResult<T>> => {
   // Await the promise in this async method and store the result in client so that they can be reused
   const requestOptions = await requestOptionsPromise;
-  const url = client.prepareUrl(requestOptions.basePath, requestOptions.queryParams);
+  const url = client.prepareUrl(
+    requestOptions.basePath, requestOptions.queryParams, repeatParamArray, unexplodedSeparator);
 
   return client.processCallWithPagination<T>({
     url,

--- a/packages/sdk-client/tests/api/api-client.test.ts
+++ b/packages/sdk-client/tests/api/api-client.test.ts
@@ -13,44 +13,33 @@ describe('API client', () => {
 
   it('should format the URL with simple parameters', () => {
     const url = 'https://example.com';
-    const parameters = {
+    const parameters = apiClient.extractQueryParams({
       foo: 'fooValue',
       bar: '1',
       baz: undefined,
-    };
+    }, ['foo', 'bar', 'baz'] );
     const formattedUrl = apiClient.prepareUrl(url, parameters);
     expect(formattedUrl).toBe('https://example.com?foo=fooValue&bar=1');
   });
 
   it('should format the URL with array parameters', () => {
     const url = 'https://example.com';
-    const parameters = {
+    const parameters = apiClient.extractQueryParams({
       foo: 'fooValue',
-      bar: '1,2',
+      bar: ['1' ,'2'],
       baz: undefined,
-    };
+    }, ['foo', 'bar', 'baz'] );
     const formattedUrl = apiClient.prepareUrl(url, parameters);
     expect(formattedUrl).toBe('https://example.com?foo=fooValue&bar=1,2');
   });
 
-  it('should format the URL with array parameters and a custom separator', () => {
-    const url = 'https://example.com';
-    const parameters = {
-      foo: 'fooValue',
-      bar: '1,2',
-      baz: undefined,
-    };
-    const formattedUrl = apiClient.prepareUrl(url, parameters, false, ';');
-    expect(formattedUrl).toBe('https://example.com?foo=fooValue&bar=1;2');
-  });
-
   it('should format the URL with array parameters with repeat key', () => {
     const url = 'https://example.com';
-    const parameters = {
+    const parameters = apiClient.extractQueryParams({
       foo: 'fooValue',
-      bar: '1,2',
+      bar: ['1' ,'2'],
       baz: undefined,
-    };
+    }, ['foo', 'bar', 'baz'] );
     const formattedUrl = apiClient.prepareUrl(url, parameters, true);
     expect(formattedUrl).toBe('https://example.com?foo=fooValue&bar=1&bar=2');
   });

--- a/packages/sdk-client/tests/api/api-client.test.ts
+++ b/packages/sdk-client/tests/api/api-client.test.ts
@@ -26,10 +26,21 @@ describe('API client', () => {
     const url = 'https://example.com';
     const parameters = {
       foo: 'fooValue',
-      bar: '1;2',
+      bar: '1,2',
       baz: undefined,
     };
     const formattedUrl = apiClient.prepareUrl(url, parameters);
+    expect(formattedUrl).toBe('https://example.com?foo=fooValue&bar=1,2');
+  });
+
+  it('should format the URL with array parameters and a custom separator', () => {
+    const url = 'https://example.com';
+    const parameters = {
+      foo: 'fooValue',
+      bar: '1,2',
+      baz: undefined,
+    };
+    const formattedUrl = apiClient.prepareUrl(url, parameters, false, ';');
     expect(formattedUrl).toBe('https://example.com?foo=fooValue&bar=1;2');
   });
 
@@ -37,7 +48,7 @@ describe('API client', () => {
     const url = 'https://example.com';
     const parameters = {
       foo: 'fooValue',
-      bar: '1;2',
+      bar: '1,2',
       baz: undefined,
     };
     const formattedUrl = apiClient.prepareUrl(url, parameters, true);


### PR DESCRIPTION
The OAS documents are not specifying the arrays of query parameters correctly:
 - in Numbers (List active numbers)
```
        - name: capability
          in: query
          description: Number capabilities to filter by, `SMS` and/or `VOICE`.
          style: form
          explode: true
          schema:
            type: array
            items:
              type: string
```
==> The server accepts `capability=SMS;VOICE` (mind the semicolon)
==> The server rejects `capability=SMS,VOICE` (mind the comma): "message": "parsing field \"capability\": \"SMS,VOICE\" is not a valid value",
==> The server rejects `capability=SMS&capability=VOICE`: "message": "too many values for field \"capability\": SMS, VOICE",
 - in conversation
```
    update_mask.paths:
      description: The set of field mask paths.
      name: update_mask.paths
      in: query
      explode: true
      schema:
        type: array
        items:
          type: string
```
==> The server accepts `update_mask=channel_priority,channel_identities,display_name`

Both specifications are incorrect as it should be `exploded: false` and the first one is even more incorrect as the parameters should be coma-separated.
Reference: https://swagger.io/docs/specification/serialization/