### PR TITLE
fix/display_name becomes optional

### DIFF
--- a/packages/conversation/src/models/v1/app-update-request/app-update-request.ts
+++ b/packages/conversation/src/models/v1/app-update-request/app-update-request.ts
@@ -15,7 +15,7 @@ export interface AppUpdateRequest {
   /** @see ConversationMetadataReportView */
   conversation_metadata_report_view?: ConversationMetadataReportView;
   /** The display name for the app. */
-  display_name: string;
+  display_name?: string;
   /** @see RetentionPolicy */
   retention_policy?: RetentionPolicy;
   /** @see DispatchRetentionPolicy */


### PR DESCRIPTION
The conversation backend released the fix to make the `display_name` optional when updating a conversation app