### PR TITLE
Do not transform to a Date object in the plugin

### DIFF
--- a/packages/sdk-client/src/plugins/timezone/timezone.response.ts
+++ b/packages/sdk-client/src/plugins/timezone/timezone.response.ts
@@ -41,7 +41,7 @@ implements ResponsePlugin<V | Record<string, any>> {
                     timestampValue = timestampValue + 'Z';
                   }
                 }
-                res[key] = new Date(timestampValue);
+                res[key] = timestampValue;
               }
             }
           }

--- a/packages/sdk-client/tests/plugins/timezone/timezone.response.test.ts
+++ b/packages/sdk-client/tests/plugins/timezone/timezone.response.test.ts
@@ -30,7 +30,7 @@ describe('Timezone response plugin', () => {
     const runner = plugin.load(context);
     const result = await runner.transform(apiResponse);
 
-    expect(result.timestamp).toStrictEqual(new Date(TIMESTAMP_WITH_TIMEZONE));
+    expect(result.timestamp).toBe(TIMESTAMP_WITH_TIMEZONE);
   });
 
   it('should NOT update the timestamp if the timezone is already there with "Z" format', async () => {
@@ -41,7 +41,7 @@ describe('Timezone response plugin', () => {
     const runner = plugin.load(context);
     const result = await runner.transform(apiResponse);
 
-    expect(result.timestamp).toStrictEqual(new Date(TIMESTAMP_WITH_TIMEZONE));
+    expect(result.timestamp).toBe(TIMESTAMP_WITH_TIMEZONE);
   });
 
   it('should update the timestamp if the timezone is already there but with "+XX format"', async () => {
@@ -52,7 +52,7 @@ describe('Timezone response plugin', () => {
     const runner = plugin.load(context);
     const result = await runner.transform(apiResponse);
 
-    expect(result.timestamp).toStrictEqual(new Date(TIMESTAMP_WITH_TIMEZONE_HOURS_MINUTES));
+    expect(result.timestamp).toBe(TIMESTAMP_WITH_TIMEZONE_HOURS_MINUTES);
   });
 
   it('should NOT update the timestamp if the timezone is already there with "+XX:XX format"', async () => {
@@ -63,7 +63,7 @@ describe('Timezone response plugin', () => {
     const runner = plugin.load(context);
     const result = await runner.transform(apiResponse);
 
-    expect(result.timestamp).toStrictEqual(new Date(TIMESTAMP_WITH_TIMEZONE_HOURS_MINUTES));
+    expect(result.timestamp).toBe(TIMESTAMP_WITH_TIMEZONE_HOURS_MINUTES);
   });
 
   it('should NOT update the timestamp if the operationId if not listed', async () => {


### PR DESCRIPTION
There is a bug in the SDK where a date is first passed into the timezone plugin and then revived into a date in the client-helper.
The revive process had been added recently and I forgot to update the plugin code to not transform the corrected string into a Date