### PR TITLE
DEVEXP-375: Enhance DX for ttl field in SendMessageRequest

### DIFF
--- a/examples/simple-examples/src/conversation/messages/send.ts
+++ b/examples/simple-examples/src/conversation/messages/send.ts
@@ -24,6 +24,7 @@ import { getAppIdFromConfig, getContactIdFromConfig, initConversationService, pr
       queue: 'HIGH_PRIORITY',
       processing_strategy: 'DEFAULT',
       channel_priority_order: ['MESSENGER'],
+      ttl_seconds: 60,
     },
   };
 

--- a/examples/simple-examples/src/conversation/messages/send.ts
+++ b/examples/simple-examples/src/conversation/messages/send.ts
@@ -24,7 +24,7 @@ import { getAppIdFromConfig, getContactIdFromConfig, initConversationService, pr
       queue: 'HIGH_PRIORITY',
       processing_strategy: 'DEFAULT',
       channel_priority_order: ['MESSENGER'],
-      ttl_seconds: 60,
+      ttl: 60,
     },
   };
 

--- a/examples/webhooks/src/services/conversation-event.service.ts
+++ b/examples/webhooks/src/services/conversation-event.service.ts
@@ -61,7 +61,7 @@ export class ConversationEventService {
               contact_id: message.contact_id!,
             },
             message: this.buildContactMessage(contactMessage),
-            ttl: '5s',
+            ttl_seconds: 5,
             channel_properties: {
               MESSENGER_NOTIFICATION_TYPE: 'NO_PUSH',
             }

--- a/examples/webhooks/src/services/conversation-event.service.ts
+++ b/examples/webhooks/src/services/conversation-event.service.ts
@@ -61,7 +61,7 @@ export class ConversationEventService {
               contact_id: message.contact_id!,
             },
             message: this.buildContactMessage(contactMessage),
-            ttl_seconds: 5,
+            ttl: 5,
             channel_properties: {
               MESSENGER_NOTIFICATION_TYPE: 'NO_PUSH',
             }

--- a/packages/conversation/src/models/v1/send-message-request/send-message-request.ts
+++ b/packages/conversation/src/models/v1/send-message-request/send-message-request.ts
@@ -36,7 +36,7 @@ export interface SendMessageRequestBase<T extends Recipient> {
   /** @see Recipient */
   recipient: T;
   /** The timeout allotted for sending the message, expressed in seconds. Passed to channels which support it and emulated by the Conversation API for channels without ttl support but with message retract/unsend functionality. Channel failover will not be performed for messages with an expired TTL. The format is an integer with the suffix `s` (for seconds). Valid integer range is 3 to 315,576,000,000 (inclusive). Example values include `10s` (10 seconds) and `86400s` (24 hours). */
-  ttl?: string;
+  ttl_seconds?: number;
   /** Overrides the app\'s [Processing Mode](../../../../../conversation/processing-modes/). Default value is `DEFAULT`. */
   processing_strategy?: ProcessingStrategy;
   /** An arbitrary identifier that will be propagated to callbacks related to this message, including MO replies. Only applicable to messages sent with the `CONVERSATION` processing mode. Up to 128 characters long. */

--- a/packages/conversation/src/models/v1/send-message-request/send-message-request.ts
+++ b/packages/conversation/src/models/v1/send-message-request/send-message-request.ts
@@ -35,9 +35,13 @@ export interface SendMessageRequestBase<T extends Recipient> {
   queue?: MessageQueue;
   /** @see Recipient */
   recipient: T;
-  /** The timeout allotted for sending the message, expressed in seconds. Passed to channels which support it and emulated by the Conversation API for channels without ttl support but with message retract/unsend functionality. Channel failover will not be performed for messages with an expired TTL. The format is an integer with the suffix `s` (for seconds). Valid integer range is 3 to 315,576,000,000 (inclusive). Example values include `10s` (10 seconds) and `86400s` (24 hours). */
+  /** The timeout allotted for sending the message, expressed in seconds. Passed to channels which support it and emulated by the Conversation API for channels without ttl support but with message retract/unsend functionality. Channel failover will not be performed for messages with an expired TTL.
+   *
+   * The format is an integer with the suffix `s` (for seconds). Valid integer range is 3 to 315,576,000,000 (inclusive). Example values include `10s` (10 seconds) and `86400s` (24 hours).
+   * The SDK will take care of the formatting: example of valid input for 10 seconds: 10 (number), "10" (string), "10s" (string)
+   */
   ttl?: string | number;
-  /** Overrides the app\'s [Processing Mode](../../../../../conversation/processing-modes/). Default value is `DEFAULT`. */
+  /** Overrides the app's [Processing Mode](../../../../../conversation/processing-modes/). Default value is `DEFAULT`. */
   processing_strategy?: ProcessingStrategy;
   /** An arbitrary identifier that will be propagated to callbacks related to this message, including MO replies. Only applicable to messages sent with the `CONVERSATION` processing mode. Up to 128 characters long. */
   correlation_id?: string;

--- a/packages/conversation/src/models/v1/send-message-request/send-message-request.ts
+++ b/packages/conversation/src/models/v1/send-message-request/send-message-request.ts
@@ -36,7 +36,7 @@ export interface SendMessageRequestBase<T extends Recipient> {
   /** @see Recipient */
   recipient: T;
   /** The timeout allotted for sending the message, expressed in seconds. Passed to channels which support it and emulated by the Conversation API for channels without ttl support but with message retract/unsend functionality. Channel failover will not be performed for messages with an expired TTL. The format is an integer with the suffix `s` (for seconds). Valid integer range is 3 to 315,576,000,000 (inclusive). Example values include `10s` (10 seconds) and `86400s` (24 hours). */
-  ttl_seconds?: number;
+  ttl?: string | number;
   /** Overrides the app\'s [Processing Mode](../../../../../conversation/processing-modes/). Default value is `DEFAULT`. */
   processing_strategy?: ProcessingStrategy;
   /** An arbitrary identifier that will be propagated to callbacks related to this message, including MO replies. Only applicable to messages sent with the `CONVERSATION` processing mode. Up to 128 characters long. */

--- a/packages/conversation/src/rest/v1/messages/messages-api.ts
+++ b/packages/conversation/src/rest/v1/messages/messages-api.ts
@@ -361,6 +361,12 @@ export class MessagesApi extends ConversationDomainApi {
       'Accept': 'application/json',
     };
 
+    // Special fields handling: ttl_seconds: number => ttl: string
+    if (data.sendMessageRequestBody.ttl_seconds !== undefined) {
+      (data as any).sendMessageRequestBody.ttl = data.sendMessageRequestBody.ttl_seconds + 's';
+      delete data.sendMessageRequestBody.ttl_seconds;
+    }
+
     const body: RequestBody = data['sendMessageRequestBody']
       ? JSON.stringify(data['sendMessageRequestBody'])
       : '{}';

--- a/packages/conversation/src/rest/v1/messages/messages-api.ts
+++ b/packages/conversation/src/rest/v1/messages/messages-api.ts
@@ -361,14 +361,11 @@ export class MessagesApi extends ConversationDomainApi {
       'Accept': 'application/json',
     };
 
-    // Special fields handling: ttl_seconds: number => ttl: string
-    if (data.sendMessageRequestBody.ttl_seconds !== undefined) {
-      (data as any).sendMessageRequestBody.ttl = data.sendMessageRequestBody.ttl_seconds + 's';
-      delete data.sendMessageRequestBody.ttl_seconds;
-    }
+    // Special fields handling: see method for details
+    const requestDataBody = this.performSendMessageRequestBodyTransformation(data.sendMessageRequestBody);
 
-    const body: RequestBody = data['sendMessageRequestBody']
-      ? JSON.stringify(data['sendMessageRequestBody'])
+    const body: RequestBody = requestDataBody
+      ? JSON.stringify(requestDataBody)
       : '{}';
     const basePathUrl = `${this.client.apiClientOptions.hostname}/v1/projects/${this.client.apiClientOptions.projectId}/messages:send`;
 
@@ -381,6 +378,20 @@ export class MessagesApi extends ConversationDomainApi {
       apiName: this.apiName,
       operationId,
     });
+  }
+
+  performSendMessageRequestBodyTransformation(
+    body: SendMessageRequest<Recipient>
+  ): SendMessageRequest<Recipient> {
+    const requestDataBody = { ...body };
+    // 'ttl' field can be a number or a string and needs to be formatted as for instance "10s" to be accepted by the server
+    if (typeof requestDataBody.ttl === 'number') {
+      requestDataBody.ttl = requestDataBody.ttl.toString();
+    }
+    if (typeof requestDataBody.ttl === 'string' && !requestDataBody.ttl.endsWith('s')) {
+      requestDataBody.ttl = requestDataBody.ttl + 's';
+    }
+    return requestDataBody;
   }
 
   /**

--- a/packages/conversation/tests/rest/v1/messages/messages-api.test.ts
+++ b/packages/conversation/tests/rest/v1/messages/messages-api.test.ts
@@ -191,7 +191,6 @@ describe('MessagesApi', () => {
       message: {
         ...messageBuilder.text(textMessageItem),
       },
-      ttl_seconds: 20,
     };
     const requestDataWithContactId: SendMessageRequestData<ContactId> = {
       sendMessageRequestBody: {
@@ -226,6 +225,22 @@ describe('MessagesApi', () => {
         expect(response).toEqual(expectedResponse);
         expect(fixture.send).toHaveBeenCalledWith(requestData);
       });
+
+    it('should format the ttl field', () => {
+      const requestBody: SendMessageRequest<Recipient> = {
+        ...sendMessageRequest,
+        ...recipientContactId,
+      };
+      requestBody.ttl = 20;
+      let formattedBody =  messagesApi.performSendMessageRequestBodyTransformation(requestBody);
+      expect(formattedBody.ttl).toBe('20s');
+      requestBody.ttl = '20';
+      formattedBody =  messagesApi.performSendMessageRequestBodyTransformation(requestBody);
+      expect(formattedBody.ttl).toBe('20s');
+      requestBody.ttl = '20s';
+      formattedBody =  messagesApi.performSendMessageRequestBodyTransformation(requestBody);
+      expect(formattedBody.ttl).toBe('20s');
+    });
   });
 
   describe ('sendCardMessage', () => {

--- a/packages/conversation/tests/rest/v1/messages/messages-api.test.ts
+++ b/packages/conversation/tests/rest/v1/messages/messages-api.test.ts
@@ -191,6 +191,7 @@ describe('MessagesApi', () => {
       message: {
         ...messageBuilder.text(textMessageItem),
       },
+      ttl_seconds: 20,
     };
     const requestDataWithContactId: SendMessageRequestData<ContactId> = {
       sendMessageRequestBody: {


### PR DESCRIPTION
This is the Node.js proposal about handling the `ttl` field for the SendMessageRequest in the Conversation API:
 - the field says what it is
 - the user just needs to give a value, the SDK takes care of the formatting