### PR TITLE
Fix discrepancies from documentation

### DIFF
--- a/packages/elastic-sip-trunking/src/models/v1/sip-endpoint/sip-endpoint.ts
+++ b/packages/elastic-sip-trunking/src/models/v1/sip-endpoint/sip-endpoint.ts
@@ -21,5 +21,5 @@ export interface SipEndpoint {
   /** The date and time that the SIP endpoint was created. */
   createTime?: Date;
   /** The date and time that the SIP endpoint was last modified. */
-  updateTime?: Date;
+  updateTime?: Date | null;
 }

--- a/packages/elastic-sip-trunking/src/models/v1/sip-trunk/sip-trunk.ts
+++ b/packages/elastic-sip-trunking/src/models/v1/sip-trunk/sip-trunk.ts
@@ -21,7 +21,7 @@ export interface SipTrunk {
   /** The date and time that the SIP trunk was created. */
   createTime?: Date;
   /** The date and time that the SIP trunk was last modified. */
-  updateTime?: Date;
+  updateTime?: Date | null;
   /** The ID of the account. */
   projectId?: string;
 }

--- a/packages/elastic-sip-trunking/src/rest/v1/sip-trunks/sip-trunks-api.ts
+++ b/packages/elastic-sip-trunking/src/rest/v1/sip-trunks/sip-trunks-api.ts
@@ -243,7 +243,7 @@ export class SipTrunksApi extends ElasticSipTrunkingDomainApi {
       pagination: PaginationEnum.PAGE2,
       apiName: this.apiName,
       operationId: 'GetSipTrunks',
-      dataKey: 'sipTrunks',
+      dataKey: 'trunks',
     };
 
     // Create the promise containing the response wrapped as a PageResult


### PR DESCRIPTION
- The `updateTime` property will always be returned, either with the value `null`, either with a date value. Note that the server returns dates in UTC but without the timezone definition.
- The list of SIP trunks is returned in a property called `trunks` and not `sipTrunks` as we can read in the [documentation](https://developers.sinch.com/docs/est/api-reference/sip-trunking/#operation/getSipTrunks!c=200&path=sipTrunks&t=response). The information has been reported to the EST team
