### PR TITLE
DEVEXP-478: E2E Conversation/Messages

### DIFF
--- a/packages/conversation/cucumber.js
+++ b/packages/conversation/cucumber.js
@@ -1,0 +1,8 @@
+module.exports = {
+  default: [
+    'tests/e2e/features/**/*.feature',
+    '--require-module ts-node/register',
+    '--require tests/rest/v1/**/*.steps.ts',
+    `--format-options '{"snippetInterface": "synchronous"}'`,
+  ].join(' '),
+};

--- a/packages/conversation/package.json
+++ b/packages/conversation/package.json
@@ -25,7 +25,8 @@
   "scripts": {
     "build": "yarn run clean && yarn run compile",
     "clean": "rimraf dist tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo",
-    "compile": "tsc -p tsconfig.build.json && tsc -p tsconfig.tests.json && rimraf dist/tests tsconfig.build.tsbuildinfo"
+    "compile": "tsc -p tsconfig.build.json && tsc -p tsconfig.tests.json && rimraf dist/tests tsconfig.build.tsbuildinfo",
+    "test:e2e": "cucumber-js"
   },
   "dependencies": {
     "@sinch/sdk-client": "^1.1.0"

--- a/packages/conversation/src/rest/v1/contact/contact-api.ts
+++ b/packages/conversation/src/rest/v1/contact/contact-api.ts
@@ -168,7 +168,7 @@ export class ContactApi extends ConversationDomainApi {
     const requestOptionsPromise = this.client.prepareOptions(basePathUrl, 'GET', getParams, headers, body || undefined);
 
     const operationProperties: PaginatedApiProperties = {
-      pagination: PaginationEnum.TOKEN,
+      pagination: PaginationEnum.TOKEN2,
       apiName: this.apiName,
       operationId: 'ListContacts',
       dataKey: 'contacts',

--- a/packages/conversation/src/rest/v1/conversation/conversation-api.ts
+++ b/packages/conversation/src/rest/v1/conversation/conversation-api.ts
@@ -201,7 +201,7 @@ export class ConversationApi extends ConversationDomainApi {
     const requestOptionsPromise = this.client.prepareOptions(basePathUrl, 'GET', getParams, headers, body || undefined);
 
     const operationProperties: PaginatedApiProperties = {
-      pagination: PaginationEnum.TOKEN,
+      pagination: PaginationEnum.TOKEN2,
       apiName: this.apiName,
       operationId: 'ListConversations',
       dataKey: 'conversations',
@@ -249,7 +249,7 @@ export class ConversationApi extends ConversationDomainApi {
     const requestOptionsPromise = this.client.prepareOptions(basePathUrl, 'GET', getParams, headers, body || undefined);
 
     const operationProperties: PaginatedApiProperties = {
-      pagination: PaginationEnum.TOKEN,
+      pagination: PaginationEnum.TOKEN2,
       apiName: this.apiName,
       operationId: 'ListRecentConversations',
       dataKey: 'conversations',

--- a/packages/conversation/src/rest/v1/events/events-api.ts
+++ b/packages/conversation/src/rest/v1/events/events-api.ts
@@ -116,7 +116,7 @@ export class EventsApi extends ConversationDomainApi {
     const requestOptionsPromise = this.client.prepareOptions(basePathUrl, 'GET', getParams, headers, body || undefined);
 
     const operationProperties: PaginatedApiProperties = {
-      pagination: PaginationEnum.TOKEN,
+      pagination: PaginationEnum.TOKEN2,
       apiName: this.apiName,
       operationId: 'ListEvents',
       dataKey: 'events',

--- a/packages/conversation/src/rest/v1/messages/messages-api.ts
+++ b/packages/conversation/src/rest/v1/messages/messages-api.ts
@@ -131,7 +131,7 @@ export class MessagesApi extends ConversationDomainApi {
     const requestOptionsPromise = this.client.prepareOptions(basePathUrl, 'GET', getParams, headers, body || undefined);
 
     const operationProperties: PaginatedApiProperties = {
-      pagination: PaginationEnum.TOKEN,
+      pagination: PaginationEnum.TOKEN2,
       apiName: this.apiName,
       operationId: 'ListMessages',
       dataKey: 'messages',

--- a/packages/conversation/tests/rest/v1/messages/messages.steps.ts
+++ b/packages/conversation/tests/rest/v1/messages/messages.steps.ts
@@ -1,0 +1,126 @@
+import { Conversation, ConversationService, MessagesApi, SupportedConversationRegion } from '../../../../src';
+import { Given, Then, When } from '@cucumber/cucumber';
+import * as assert from 'assert';
+import { PageResult } from '@sinch/sdk-client';
+
+let messagesApi: MessagesApi;
+let messageResponse: Conversation.SendMessageResponse;
+let listResponse: PageResult<Conversation.ConversationMessage>;
+const messagesList: Conversation.ConversationMessage[] = [];
+let message: Conversation.ConversationMessage;
+let deleteMessageResponse: void;
+
+Given('the Conversation service "Messages" is available', function () {
+  const conversationService = new ConversationService({
+    projectId: 'tinyfrog-jump-high-over-lilypadbasin',
+    keyId: 'keyId',
+    keySecret: 'keySecret',
+    authHostname: 'http://localhost:3011',
+    conversationHostname: 'http://localhost:3014',
+    conversationRegion: SupportedConversationRegion.UNITED_STATES,
+  });
+  messagesApi = conversationService.messages;
+});
+
+When('I send a request to send a message to a contact', async () => {
+  messageResponse = await messagesApi.send({
+    sendMessageRequestBody: {
+      message: {
+        text_message: {
+          text: 'Hello',
+        },
+      },
+      app_id: '01W4FFL35P4NC4K35CONVAPP001',
+      recipient: {
+        contact_id: '01W4FFL35P4NC4K35CONTACT001',
+      },
+    },
+  });
+});
+
+Then('the response contains the id of the message', () => {
+  assert.equal(messageResponse.message_id, '01W4FFL35P4NC4K35MESSAGE001');
+});
+
+When('I send a request to list the existing messages', async () => {
+  listResponse = await messagesApi.list({
+    page_size: 2,
+  });
+});
+
+Then('the response contains {string} messages', (expectedAnswer: string) => {
+  const expectedMessagesCount = parseInt(expectedAnswer, 10);
+  assert.equal(listResponse.data.length, expectedMessagesCount);
+});
+
+When('I send a request to list all the messages', async () => {
+  for await (const service of messagesApi.list({ page_size: 2 })) {
+    messagesList.push(service);
+  }
+});
+
+When('I iterate manually over the messages pages', async () => {
+  listResponse = await messagesApi.list({
+    page_size: 2,
+  });
+  let reachedEndOfPages = false;
+  while (!reachedEndOfPages) {
+    if (listResponse.hasNextPage) {
+      listResponse = await listResponse.nextPage();
+    } else {
+      reachedEndOfPages = true;
+    }
+  }
+});
+
+Then('the messages list contains {string} messages',  (expectedAnswer: string) => {
+  const expectedServices = parseInt(expectedAnswer, 10);
+  assert.equal(messagesList.length, expectedServices);
+});
+
+When('I send a request to retrieve a message', async () => {
+  message = await messagesApi.get({
+    message_id: '01W4FFL35P4NC4K35MESSAGE001',
+  });
+});
+
+Then('the response contains the message details', () => {
+  assert.equal(message.id, '01W4FFL35P4NC4K35MESSAGE001');
+  assert.equal(message.direction, 'TO_CONTACT');
+  assert.equal(message.conversation_id, '01W4FFL35P4NC4K35CONVERSATI');
+  assert.equal(message.contact_id, '01W4FFL35P4NC4K35CONTACT001');
+  assert.equal(message.metadata, '');
+  assert.deepEqual(message.accept_time, new Date('2024-06-06T12:42:42Z'));
+  assert.equal(message.processing_mode, 'CONVERSATION');
+  assert.equal(message.injected, false);
+  const channelIdentity: Conversation.ChannelIdentity = {
+    channel: 'SMS',
+    identity: '12015555555',
+    app_id: '',
+  };
+  assert.deepEqual(message.channel_identity, channelIdentity);
+});
+
+When('I send a request to update a message', async () => {
+  message = await messagesApi.update({
+    message_id: '01W4FFL35P4NC4K35MESSAGE001',
+    updateMessageRequestBody: {
+      metadata: 'Updated metadata',
+    },
+  });
+});
+
+Then('the response contains the message details with updated metadata', () => {
+  assert.equal(message.id, '01W4FFL35P4NC4K35MESSAGE001');
+  assert.equal(message.metadata, 'Updated metadata');
+});
+
+When('I send a request to delete a message', async () => {
+  deleteMessageResponse = await messagesApi.delete({
+    message_id: '01W4FFL35P4NC4K35MESSAGE001',
+  });
+});
+
+Then('the delete message response contains no data', () => {
+  assert.deepEqual(deleteMessageResponse, {} );
+});

--- a/packages/conversation/tests/rest/v1/messages/messages.steps.ts
+++ b/packages/conversation/tests/rest/v1/messages/messages.steps.ts
@@ -9,6 +9,7 @@ let listResponse: PageResult<Conversation.ConversationMessage>;
 const messagesList: Conversation.ConversationMessage[] = [];
 let message: Conversation.ConversationMessage;
 let deleteMessageResponse: void;
+let pagesIteration: number;
 
 Given('the Conversation service "Messages" is available', function () {
   const conversationService = new ConversationService({
@@ -63,10 +64,12 @@ When('I iterate manually over the messages pages', async () => {
   listResponse = await messagesApi.list({
     page_size: 2,
   });
+  pagesIteration = 1;
   let reachedEndOfPages = false;
   while (!reachedEndOfPages) {
     if (listResponse.hasNextPage) {
       listResponse = await listResponse.nextPage();
+      pagesIteration++;
     } else {
       reachedEndOfPages = true;
     }
@@ -76,6 +79,11 @@ When('I iterate manually over the messages pages', async () => {
 Then('the messages list contains {string} messages',  (expectedAnswer: string) => {
   const expectedServices = parseInt(expectedAnswer, 10);
   assert.equal(messagesList.length, expectedServices);
+});
+
+Then('the result contains the data from {string} pages',  (expectedAnswer: string) => {
+  const expectedPagesCount = parseInt(expectedAnswer, 10);
+  assert.equal(pagesIteration, expectedPagesCount);
 });
 
 When('I send a request to retrieve a message', async () => {

--- a/packages/sdk-client/src/api/api-client.ts
+++ b/packages/sdk-client/src/api/api-client.ts
@@ -6,6 +6,8 @@ export enum PaginationEnum {
   NONE,
   /** Used by the Numbers API */
   TOKEN,
+  /** Used by the Conversation API */
+  TOKEN2,
   /** used by the SMS API */
   PAGE,
   /** used by the Elastic SIP Trunking API */

--- a/packages/sdk-client/src/client/api-client-pagination-helper.ts
+++ b/packages/sdk-client/src/client/api-client-pagination-helper.ts
@@ -60,6 +60,13 @@ class SinchIterator<T> implements AsyncIterator<T> {
       return updateQueryParamsAndSendRequest(
         this.apiClient, newParams, requestOptions, this.paginatedOperationProperties);
     }
+    if (this.paginatedOperationProperties.pagination === PaginationEnum.TOKEN2) {
+      const newParams = {
+        page_token: pageResult.nextPageValue,
+      };
+      return updateQueryParamsAndSendRequest(
+        this.apiClient, newParams, requestOptions, this.paginatedOperationProperties);
+    }
     if (this.paginatedOperationProperties.pagination === PaginationEnum.PAGE
       || this.paginatedOperationProperties.pagination === PaginationEnum.PAGE3) {
       const newParams = {
@@ -136,6 +143,11 @@ export const createNextPageMethod = <T>(
       pageToken: nextPageValue,
     };
     break;
+  case PaginationEnum.TOKEN2:
+    newParams = {
+      page_token: nextPageValue,
+    };
+    break;
   case PaginationEnum.PAGE:
   case PaginationEnum.PAGE2:
   case PaginationEnum.PAGE3:
@@ -167,7 +179,10 @@ export function hasMore(
   context: PaginationContext,
 ): boolean {
   if (context.pagination === PaginationEnum.TOKEN) {
-    return !!response['nextPageToken'] || !!response['next_page_token'];
+    return !!response['nextPageToken'];
+  }
+  if (context.pagination === PaginationEnum.TOKEN2) {
+    return !!response['next_page_token'];
   }
   if (context.pagination === PaginationEnum.PAGE) {
     const requestedPageSize = context.requestOptions.queryParams?.page_size;
@@ -190,7 +205,10 @@ export function calculateNextPage(
   context: PaginationContext,
 ): string {
   if (context.pagination === PaginationEnum.TOKEN) {
-    return response['nextPageToken'] || response['next_page_token'];
+    return response['nextPageToken'];
+  }
+  if (context.pagination === PaginationEnum.TOKEN2) {
+    return response['next_page_token'];
   }
   if (context.pagination === PaginationEnum.PAGE) {
     const currentPage: number = response.page || 0;

--- a/packages/sdk-client/tests/client/api-client-pagination-helpers.test.ts
+++ b/packages/sdk-client/tests/client/api-client-pagination-helpers.test.ts
@@ -21,6 +21,10 @@ describe('API Client Pagination Helper', () => {
     pagination: PaginationEnum.TOKEN,
     ...paginationTokenProperties,
   };
+  const paginationContextToken2: PaginationContext = {
+    pagination: PaginationEnum.TOKEN2,
+    ...paginationTokenProperties,
+  };
   const paginationContextPage: PaginationContext = {
     pagination: PaginationEnum.PAGE,
     ...paginationTokenProperties,
@@ -61,6 +65,38 @@ describe('API Client Pagination Helper', () => {
         totalSize: 2,
       };
       const paginationContext = { ...paginationContextToken };
+
+      // When
+      const hasMoreElements = hasMore(response, paginationContext);
+
+      // Then
+      expect(hasMoreElements).toBeFalsy();
+    });
+
+    it('should return "true" when the PaginationContext is "TOKEN2" and there are more elements', async () => {
+      // Given
+      const response = {
+        elements: ['H', 'He'],
+        next_page_token: 'nextPageToken',
+        totalSize: 10,
+      };
+      const paginationContext = { ...paginationContextToken2 };
+
+      // When
+      const hasMoreElements = hasMore(response, paginationContext);
+
+      // Then
+      expect(hasMoreElements).toBeTruthy();
+    });
+
+    it('should return "false" when the PaginationContext is "TOKEN2" and there are no more elements', async () => {
+      // Given
+      const response = {
+        elements: ['H', 'He'],
+        next_page_token: '',
+        totalSize: 2,
+      };
+      const paginationContext = { ...paginationContextToken2 };
 
       // When
       const hasMoreElements = hasMore(response, paginationContext);
@@ -185,6 +221,22 @@ describe('API Client Pagination Helper', () => {
         totalSize: 10,
       };
       const paginationContext = { ...paginationContextToken };
+
+      // When
+      const nextPage = calculateNextPage(response, paginationContext);
+
+      // Then
+      expect(nextPage).toBe('nextPageToken');
+    });
+
+    it('should return the next page token when the PaginationContext is "TOKEN2"', () => {
+      // Given
+      const response = {
+        elements: ['H', 'He'],
+        next_page_token: 'nextPageToken',
+        totalSize: 10,
+      };
+      const paginationContext = { ...paginationContextToken2 };
 
       // When
       const nextPage = calculateNextPage(response, paginationContext);


### PR DESCRIPTION
On top of adding steps for the Conversation / Messages, this PR fixes a bug in the pagination for the Conversation API: it was using the mode `TOKEN` designed for the Numbers API, but the pagination parameter are different in the Conversation API (snake_case) so I had to create the mode `TOKEN_2` to handle it properly.
Note: before commenting about `TOKEN_2` being not explicit enough, I want to highlight that it is not exposed to the end user and since the pagination is finally different for all the APIs integrated in the SDK, I'll have to re-think about the initial design in another ticket to create, refine and prioritise.