### PR TITLE
DEVEXP-493: Use healthcheck script in CI

### DIFF
--- a/.github/workflows/run-ci.yaml
+++ b/.github/workflows/run-ci.yaml
@@ -44,6 +44,7 @@ jobs:
       - name: Wait for the mock servers to be healthy
         run: |
           cd sinch-sdk-mockserver
+          chmod +x ./scripts/healthcheck.sh
           ./scripts/healthcheck.sh
       - name: Create target directories for feature files
         run: |

--- a/.github/workflows/run-ci.yaml
+++ b/.github/workflows/run-ci.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: sinch/sinch-sdk-mockserver
+          ref: DEVEXP-493_Healthcheck-script
           token: ${{ secrets.PAT_CI }}
           fetch-depth: 0
           path: sinch-sdk-mockserver
@@ -43,26 +44,7 @@ jobs:
       - name: Wait for the mock servers to be healthy
         run: |
           cd sinch-sdk-mockserver
-          servers=(
-            "authentication-server"
-            "fax-server"
-            "numbers-server"
-            "conversation-server"
-            "conversation-templates-server"
-          )
-          
-          for server in "${servers[@]}"; do
-            SECONDS=0
-            while ! docker inspect --format='{{json .State.Health.Status}}' $(docker-compose ps -q $server) | grep -q '"healthy"'; do
-              if [ $SECONDS -ge 30 ]; then
-                echo "Timeout: $server did not become healthy within 30 seconds."
-                exit 1
-              fi
-              echo "Waiting for $server to be healthy..."
-              sleep 2
-            done
-            echo "$server is healthy!"
-          done
+          ./scripts/healthcheck.sh
       - name: Create target directories for feature files
         run: |
           mkdir -p ./packages/fax/tests/e2e/features

--- a/.github/workflows/run-ci.yaml
+++ b/.github/workflows/run-ci.yaml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: sinch/sinch-sdk-mockserver
-          ref: DEVEXP-493_Healthcheck-script
           token: ${{ secrets.PAT_CI }}
           fetch-depth: 0
           path: sinch-sdk-mockserver


### PR DESCRIPTION
The build will fail while the PR in the mockserver repo is not merged
EDIT: the build is passing now