### PR TITLE
DEVEXP-518: E2E SMS/Groups

### DIFF
--- a/examples/simple-examples/src/sms/groups/list/list.ts
+++ b/examples/simple-examples/src/sms/groups/list/list.ts
@@ -6,14 +6,14 @@ import {
 import { getPrintFormat, printFullResponse } from '../../../config';
 
 const populateGroupsList = (
-  groupsPage: PageResult<Sms.CreateGroupResponse>,
-  fullGroupsList: Sms.CreateGroupResponse[],
+  groupsPage: PageResult<Sms.Group>,
+  fullGroupsList: Sms.Group[],
   groupsList: string[],
 ) => {
   // Populate the data structure that holds the response content
   fullGroupsList.push(...groupsPage.data);
   // Populate the data structure that holds the response content for pretty print
-  groupsPage.data.map((group: Sms.CreateGroupResponse) => {
+  groupsPage.data.map((group: Sms.Group) => {
     groupsList.push(`Group ID: ${group.id} - Group name: ${group.name}`);
   });
 };
@@ -39,7 +39,7 @@ export const list = async(smsService: SmsService) => {
   }
 
   // Init data structure to hold the response content
-  const fullGroupsList: Sms.CreateGroupResponse[] = [];
+  const fullGroupsList: Sms.Group[] = [];
   // Init data structure to hold the response content for pretty print
   const groupsList: string[] = [];
 

--- a/packages/sms/src/models/v1/create-group-response/index.ts
+++ b/packages/sms/src/models/v1/create-group-response/index.ts
@@ -1,4 +1,0 @@
-export type { CreateGroupResponse } from './create-group-response';
-export type { CreateGroupResponse as GroupResponse } from './create-group-response';
-export type { CreateGroupResponse as ReplaceGroupResponse } from './create-group-response';
-export type { CreateGroupResponse as UpdateGroupResponse } from './create-group-response';

--- a/packages/sms/src/models/v1/group/group.ts
+++ b/packages/sms/src/models/v1/group/group.ts
@@ -1,6 +1,6 @@
 import { GroupAutoUpdate } from '../group-auto-update';
 
-export interface CreateGroupResponse {
+export interface Group {
 
   /** The ID used to reference this group. */
   id?: string;

--- a/packages/sms/src/models/v1/group/index.ts
+++ b/packages/sms/src/models/v1/group/index.ts
@@ -1,0 +1,1 @@
+export type { Group } from './group';

--- a/packages/sms/src/models/v1/index.ts
+++ b/packages/sms/src/models/v1/index.ts
@@ -9,7 +9,7 @@ export * from './api-update-mt-message';
 export * from './api-update-text-mt-message';
 export * from './binary-request';
 export * from './binary-response';
-export * from './create-group-response';
+export * from './group';
 export * from './delivery-report';
 export * from './delivery-report-list';
 export * from './dry-run-request';

--- a/packages/sms/src/models/v1/list-groups-response/list-groups-response.ts
+++ b/packages/sms/src/models/v1/list-groups-response/list-groups-response.ts
@@ -1,4 +1,4 @@
-import { CreateGroupResponse } from '../create-group-response';
+import { Group } from '../group';
 
 export interface ListGroupsResponse {
 
@@ -9,7 +9,7 @@ export interface ListGroupsResponse {
   /** The total number of groups. */
   count?: number;
   /** List of GroupObjects */
-  groups?: CreateGroupResponse[];
+  groups?: Group[];
 }
 
 

--- a/packages/sms/src/models/v1/update-group-request/update-group-request.ts
+++ b/packages/sms/src/models/v1/update-group-request/update-group-request.ts
@@ -3,7 +3,7 @@ import { UpdateGroupRequestAutoUpdate } from '../update-group-request-auto-updat
 export interface UpdateGroupRequest {
 
   /** The name of the group. Omitting `name` from the JSON body will leave the name unchanged. To remove an existing name set, name explicitly to the JSON value `null`. */
-  name?: string;
+  name?: string | null;
   /** Add a list of phone numbers (MSISDNs) to this group. The phone numbers are a strings within an array and must be in <a href=\"https://community.sinch.com/t5/Glossary/E-164/ta-p/7537\" target=\"_blank\">E.164 format</a>. */
   add?: string[];
   /** Remove a list of phone numbers (MSISDNs) to this group.The phone numbers are a strings within an array and must be in <a href=\"https://community.sinch.com/t5/Glossary/E-164/ta-p/7537\" target=\"_blank\">E.164 format</a>. */

--- a/packages/sms/src/rest/v1/groups/groups-api.jest.fixture.ts
+++ b/packages/sms/src/rest/v1/groups/groups-api.jest.fixture.ts
@@ -1,7 +1,6 @@
 import { GroupsApi } from './groups-api';
 import {
-  CreateGroupResponse,
-  GroupResponse,
+  Group,
   CreateGroupRequestData,
   DeleteGroupRequestData,
   ListMembersRequestData,
@@ -17,7 +16,7 @@ export class GroupsApiFixture implements Partial<Readonly<GroupsApi>> {
   /**
    * Fixture associated to function createGroup
    */
-  public create: jest.Mock<Promise<CreateGroupResponse>, [CreateGroupRequestData]> = jest.fn();
+  public create: jest.Mock<Promise<Group>, [CreateGroupRequestData]> = jest.fn();
   /**
    * Fixture associated to function deleteGroup
    */
@@ -29,17 +28,17 @@ export class GroupsApiFixture implements Partial<Readonly<GroupsApi>> {
   /**
    * Fixture associated to function listGroups
    */
-  public list: jest.Mock<ApiListPromise<GroupResponse>, [ListGroupsRequestData]> = jest.fn();
+  public list: jest.Mock<ApiListPromise<Group>, [ListGroupsRequestData]> = jest.fn();
   /**
    * Fixture associated to function replaceGroup
    */
-  public replace: jest.Mock<Promise<GroupResponse>, [ReplaceGroupRequestData]> = jest.fn();
+  public replace: jest.Mock<Promise<Group>, [ReplaceGroupRequestData]> = jest.fn();
   /**
    * Fixture associated to function retrieveGroup
    */
-  public get: jest.Mock<Promise<GroupResponse>, [GetGroupRequestData]> = jest.fn();
+  public get: jest.Mock<Promise<Group>, [GetGroupRequestData]> = jest.fn();
   /**
    * Fixture associated to function updateGroup
    */
-  public update: jest.Mock<Promise<GroupResponse>, [UpdateGroupRequestData]> = jest.fn();
+  public update: jest.Mock<Promise<Group>, [UpdateGroupRequestData]> = jest.fn();
 }

--- a/packages/sms/src/rest/v1/groups/groups-api.ts
+++ b/packages/sms/src/rest/v1/groups/groups-api.ts
@@ -1,9 +1,12 @@
 import {
   CreateGroupRequestData,
-  CreateGroupResponse, DeleteGroupRequestData, GetGroupRequestData,
-  GroupResponse, ListGroupsRequestData, ListMembersRequestData, ReplaceGroupRequestData,
-  ReplaceGroupResponse, UpdateGroupRequestData,
-  UpdateGroupResponse,
+  DeleteGroupRequestData,
+  GetGroupRequestData,
+  ListGroupsRequestData,
+  ListMembersRequestData,
+  ReplaceGroupRequestData,
+  UpdateGroupRequestData,
+  Group,
 } from '../../../models';
 import {
   RequestBody,
@@ -32,7 +35,7 @@ export class GroupsApi extends SmsDomainApi {
    * A group is a set of phone numbers (MSISDNs) that can be used as a target in the &#x60;send_batch_msg&#x60; operation. An MSISDN can only occur once in a group and any attempts to add a duplicate would be ignored but not rejected.
    * @param { CreateGroupRequestData } data - The data to provide to the API call.
    */
-  public async create(data: CreateGroupRequestData): Promise<CreateGroupResponse> {
+  public async create(data: CreateGroupRequestData): Promise<Group> {
     this.client = this.getSinchClient();
     const getParams = this.client.extractQueryParams<CreateGroupRequestData>(data, [] as never[]);
     const headers: { [key: string]: string | undefined } = {
@@ -47,7 +50,7 @@ export class GroupsApi extends SmsDomainApi {
       = await this.client.prepareOptions(basePathUrl, 'POST', getParams, headers, body || undefined);
     const url = this.client.prepareUrl(requestOptions.hostname, requestOptions.queryParams);
 
-    return this.client.processCall<CreateGroupResponse>({
+    return this.client.processCall<Group>({
       url,
       requestOptions,
       apiName: this.apiName,
@@ -115,12 +118,10 @@ export class GroupsApi extends SmsDomainApi {
    * List Groups
    * With the list operation you can list all groups that you have created. This operation supports pagination.  Groups are returned in reverse chronological order.
    * @param { ListGroupsRequestData } data - The data to provide to the API call.
-   * @return {ApiListPromise<CreateGroupResponse>}
+   * @return {ApiListPromise<Group>}
    */
-  public list(data: ListGroupsRequestData): ApiListPromise<GroupResponse> {
+  public list(data: ListGroupsRequestData): ApiListPromise<Group> {
     this.client = this.getSinchClient();
-    data['page'] = data['page'] !== undefined ? data['page'] : 0;
-    data['page_size'] = data['page_size'] !== undefined ? data['page_size'] : 30;
     const getParams = this.client.extractQueryParams<ListGroupsRequestData>(data, ['page', 'page_size']);
     const headers: { [key: string]: string | undefined } = {
       'Content-Type': 'application/json',
@@ -141,7 +142,7 @@ export class GroupsApi extends SmsDomainApi {
     };
 
     // Create the promise containing the response wrapped as a PageResult
-    const listPromise = buildPageResultPromise<GroupResponse>(
+    const listPromise = buildPageResultPromise<Group>(
       this.client,
       requestOptionsPromise,
       operationProperties);
@@ -149,11 +150,11 @@ export class GroupsApi extends SmsDomainApi {
     // Add properties to the Promise to offer the possibility to use it as an iterator
     Object.assign(
       listPromise,
-      createIteratorMethodsForPagination<GroupResponse>(
+      createIteratorMethodsForPagination<Group>(
         this.client, requestOptionsPromise, listPromise, operationProperties),
     );
 
-    return listPromise as ApiListPromise<GroupResponse>;
+    return listPromise as ApiListPromise<Group>;
   }
 
   /**
@@ -161,7 +162,7 @@ export class GroupsApi extends SmsDomainApi {
    * The replace operation will replace all parameters, including members, of an existing group with new values.  Replacing a group targeted by a batch message scheduled in the future is allowed and changes will be reflected when the batch is sent.
    * @param { ReplaceGroupRequestData } data - The data to provide to the API call.
    */
-  public async replace(data: ReplaceGroupRequestData): Promise<ReplaceGroupResponse> {
+  public async replace(data: ReplaceGroupRequestData): Promise<Group> {
     this.client = this.getSinchClient();
     const getParams = this.client.extractQueryParams<ReplaceGroupRequestData>(data, [] as never[]);
     const headers: { [key: string]: string | undefined } = {
@@ -176,7 +177,7 @@ export class GroupsApi extends SmsDomainApi {
       = await this.client.prepareOptions(basePathUrl, 'PUT', getParams, headers, body || undefined);
     const url = this.client.prepareUrl(requestOptions.hostname, requestOptions.queryParams);
 
-    return this.client.processCall<ReplaceGroupResponse>({
+    return this.client.processCall<Group>({
       url,
       requestOptions,
       apiName: this.apiName,
@@ -189,7 +190,7 @@ export class GroupsApi extends SmsDomainApi {
    * This operation retrieves a specific group with the provided group ID.
    * @param { GetGroupRequestData } data - The data to provide to the API call.
    */
-  public async get(data: GetGroupRequestData): Promise<GroupResponse> {
+  public async get(data: GetGroupRequestData): Promise<Group> {
     this.client = this.getSinchClient();
     const getParams = this.client.extractQueryParams<GetGroupRequestData>(data, [] as never[]);
     const headers: { [key: string]: string | undefined } = {
@@ -204,7 +205,7 @@ export class GroupsApi extends SmsDomainApi {
       = await this.client.prepareOptions(basePathUrl, 'GET', getParams, headers, body || undefined);
     const url = this.client.prepareUrl(requestOptions.hostname, requestOptions.queryParams);
 
-    return this.client.processCall<GroupResponse>({
+    return this.client.processCall<Group>({
       url,
       requestOptions,
       apiName: this.apiName,
@@ -217,7 +218,7 @@ export class GroupsApi extends SmsDomainApi {
    * With the update group operation, you can add and remove members in an existing group as well as rename the group.  This method encompasses a few ways to update a group:  1. By using &#x60;add&#x60; and &#x60;remove&#x60; arrays containing phone numbers, you control the group movements. Any list of valid numbers in E.164 format can be added. 2. By using the &#x60;auto_update&#x60; object, your customer can add or remove themselves from groups.  3. You can also add or remove other groups into this group with &#x60;add_from_group&#x60; and &#x60;remove_from_group&#x60;.  #### Other group update info  - The request will not be rejected for duplicate adds or unknown removes. - The additions will be done before the deletions. If an phone number is on both lists, it will not be apart of the resulting group. - Updating a group targeted by a batch message scheduled in the future is allowed. Changes will be reflected when the batch is sent.
    * @param { UpdateGroupRequestData } data - The data to provide to the API call.
    */
-  public async update(data: UpdateGroupRequestData): Promise<UpdateGroupResponse> {
+  public async update(data: UpdateGroupRequestData): Promise<Group> {
     this.client = this.getSinchClient();
     const getParams = this.client.extractQueryParams<UpdateGroupRequestData>(data, [] as never[]);
     const headers: { [key: string]: string | undefined } = {
@@ -232,7 +233,7 @@ export class GroupsApi extends SmsDomainApi {
       = await this.client.prepareOptions(basePathUrl, 'POST', getParams, headers, body || undefined);
     const url = this.client.prepareUrl(requestOptions.hostname, requestOptions.queryParams);
 
-    return this.client.processCall<UpdateGroupResponse>({
+    return this.client.processCall<Group>({
       url,
       requestOptions,
       apiName: this.apiName,

--- a/packages/sms/tests/rest/v1/groups/groups-api.test.ts
+++ b/packages/sms/tests/rest/v1/groups/groups-api.test.ts
@@ -31,7 +31,7 @@ describe('GroupsApi', () => {
           ],
         },
       };
-      const expectedResponse: Sms.CreateGroupResponse = {
+      const expectedResponse: Sms.Group = {
         id: '01HF6EFE21REWJC3B3JWG4FYZ7',
         name: 'My group',
         size: 2,
@@ -96,7 +96,7 @@ describe('GroupsApi', () => {
       // Given
       const requestData: Sms.ListGroupsRequestData = {};
 
-      const mockData: Sms.GroupResponse[] =[
+      const mockData: Sms.Group[] =[
         {
           id: '01HF6EFE21REWJC3B3JWG4FYZ7',
           name: 'My group',
@@ -137,7 +137,7 @@ describe('GroupsApi', () => {
           ],
         },
       };
-      const expectedResponse: Sms.GroupResponse = {
+      const expectedResponse: Sms.Group = {
         id: '01HF6EFE21REWJC3B3JWG4FYZ7',
         name: 'My new group name',
         size: 1,
@@ -162,7 +162,7 @@ describe('GroupsApi', () => {
       const requestData: Sms.GetGroupRequestData = {
         group_id: '01HF6EFE21REWJC3B3JWG4FYZ7',
       };
-      const expectedResponse: Sms.GroupResponse = {
+      const expectedResponse: Sms.Group = {
         id: '01HF6EFE21REWJC3B3JWG4FYZ7',
         name: 'My new group name',
         size: 1,
@@ -193,7 +193,7 @@ describe('GroupsApi', () => {
           ],
         },
       };
-      const expectedResponse: Sms.GroupResponse = {
+      const expectedResponse: Sms.Group = {
         id: '01HF6EFE21REWJC3B3JWG4FYZ7',
         name: 'My new group name',
         size: 3,

--- a/packages/sms/tests/rest/v1/groups/groups.steps.ts
+++ b/packages/sms/tests/rest/v1/groups/groups.steps.ts
@@ -104,7 +104,7 @@ When('I send a request to update an SMS group', async () => {
   group = await groupsApi.update({
     group_id: '01W4FFL35P4NC4K35SMSGROUP1',
     updateGroupRequestBody: {
-      name: null,
+      name: 'Updated group name',
       add: [
         '+12017771111',
         '+12017772222',
@@ -121,12 +121,26 @@ When('I send a request to update an SMS group', async () => {
 
 Then('the response contains the updated SMS group details', () => {
   assert.equal(group.id, '01W4FFL35P4NC4K35SMSGROUP1');
-  assert.equal(group.name, undefined);
+  assert.equal(group.name, 'Updated group name');
   assert.equal(group.size, 6);
   assert.deepEqual(group.created_at, new Date('2024-06-06T08:59:22.156Z'));
   assert.deepEqual(group.modified_at, new Date('2024-06-06T09:19:58.147Z'));
   assert.ok(group.child_groups);
   assert.equal(group.child_groups[0], '01W4FFL35P4NC4K35SUBGROUP1');
+});
+
+When('I send a request to update an SMS group to remove its name', async () => {
+  group = await groupsApi.update({
+    group_id: '01W4FFL35P4NC4K35SMSGROUP2',
+    updateGroupRequestBody: {
+      name: null,
+    },
+  });
+});
+
+Then('the response contains the updated SMS group details where the name has been removed', () => {
+  assert.equal(group.id, '01W4FFL35P4NC4K35SMSGROUP2');
+  assert.equal(group.name, undefined);
 });
 
 When('I send a request to replace an SMS group', async () => {

--- a/packages/sms/tests/rest/v1/groups/groups.steps.ts
+++ b/packages/sms/tests/rest/v1/groups/groups.steps.ts
@@ -1,0 +1,177 @@
+import { GroupsApi, SmsService, Sms } from '../../../../src';
+import { Given, When, Then } from '@cucumber/cucumber';
+import * as assert from 'assert';
+import { PageResult } from '@sinch/sdk-client';
+
+let groupsApi: GroupsApi;
+let group: Sms.Group;
+let listResponse: PageResult<Sms.Group>;
+let groupsList: Sms.Group[];
+let pagesIteration: number;
+let deleteGroupResponse: void;
+let phoneNumbersList: string[];
+
+Given('the SMS service "Groups" is available', () => {
+  const smsService = new SmsService({
+    projectId: 'tinyfrog-jump-high-over-lilypadbasin',
+    keyId: 'keyId',
+    keySecret: 'keySecret',
+    authHostname: 'http://localhost:3011',
+    smsHostname: 'http://localhost:3017',
+  });
+  groupsApi = smsService.groups;
+});
+
+When('I send a request to create an SMS group', async () => {
+  group = await groupsApi.create({
+    createGroupRequestBody: {
+      name: 'Group master',
+      members: [
+        '+12017778888',
+        '+12018887777',
+      ],
+      child_groups: [
+        '01W4FFL35P4NC4K35SUBGROUP1',
+      ],
+    },
+  });
+});
+
+Then('the response contains the SMS group details', () => {
+  assert.equal(group.id, '01W4FFL35P4NC4K35SMSGROUP1');
+  assert.equal(group.name, 'Group master');
+  assert.equal(group.size, 2);
+  assert.deepEqual(group.created_at, new Date('2024-06-06T08:59:22.156Z'));
+  assert.deepEqual(group.modified_at, new Date('2024-06-06T08:59:22.156Z'));
+  assert.ok(group.child_groups);
+  assert.equal(group.child_groups[0], '01W4FFL35P4NC4K35SUBGROUP1');
+});
+
+When('I send a request to list the existing SMS groups', async () => {
+  listResponse = await groupsApi.list({
+    page_size: 2,
+  });
+});
+
+Then('the response contains {string} SMS groups', (expectedAnswer: string) => {
+  const expectedGroupsCount = parseInt(expectedAnswer, 10);
+  assert.equal(listResponse.data.length, expectedGroupsCount);
+});
+
+When('I send a request to list all the SMS groups', async () => {
+  groupsList = [];
+  for await (const group of groupsApi.list({ page_size: 2 })) {
+    groupsList.push(group);
+  }
+});
+
+When('I iterate manually over the SMS groups pages', async () => {
+  groupsList = [];
+  listResponse = await groupsApi.list({
+    page_size: 2,
+  });
+  groupsList.push(...listResponse.data);
+  pagesIteration = 1;
+  let reachedEndOfPages = false;
+  while (!reachedEndOfPages) {
+    if (listResponse.hasNextPage) {
+      listResponse = await listResponse.nextPage();
+      groupsList.push(...listResponse.data);
+      pagesIteration++;
+    } else {
+      reachedEndOfPages = true;
+    }
+  }
+});
+
+Then('the SMS groups list contains {string} SMS groups',  (expectedAnswer: string) => {
+  const expectedGroupsCount = parseInt(expectedAnswer, 10);
+  assert.equal(groupsList.length, expectedGroupsCount);
+});
+
+Then('the SMS groups iteration result contains the data from {string} pages',  (expectedAnswer: string) => {
+  const expectedPagesCount = parseInt(expectedAnswer, 10);
+  assert.equal(pagesIteration, expectedPagesCount);
+});
+
+When('I send a request to retrieve an SMS group', async () => {
+  group = await groupsApi.get({
+    group_id: '01W4FFL35P4NC4K35SMSGROUP1',
+  });
+});
+
+When('I send a request to update an SMS group', async () => {
+  group = await groupsApi.update({
+    group_id: '01W4FFL35P4NC4K35SMSGROUP1',
+    updateGroupRequestBody: {
+      name: null,
+      add: [
+        '+12017771111',
+        '+12017772222',
+      ],
+      remove: [
+        '+12017773333',
+        '+12017774444',
+      ],
+      add_from_group: '01W4FFL35P4NC4K35SMSGROUP2',
+      remove_from_group: '01W4FFL35P4NC4K35SMSGROUP3',
+    },
+  });
+});
+
+Then('the response contains the updated SMS group details', () => {
+  assert.equal(group.id, '01W4FFL35P4NC4K35SMSGROUP1');
+  assert.equal(group.name, undefined);
+  assert.equal(group.size, 6);
+  assert.deepEqual(group.created_at, new Date('2024-06-06T08:59:22.156Z'));
+  assert.deepEqual(group.modified_at, new Date('2024-06-06T09:19:58.147Z'));
+  assert.ok(group.child_groups);
+  assert.equal(group.child_groups[0], '01W4FFL35P4NC4K35SUBGROUP1');
+});
+
+When('I send a request to replace an SMS group', async () => {
+  group = await groupsApi.replace({
+    group_id: '01W4FFL35P4NC4K35SMSGROUP1',
+    replaceGroupRequestBody: {
+      name: 'Replacement group',
+      members: [
+        '+12018881111',
+        '+12018882222',
+        '+12018883333',
+      ],
+    },
+  });
+});
+
+Then('the response contains the replaced SMS group details', () => {
+  assert.equal(group.id, '01W4FFL35P4NC4K35SMSGROUP1');
+  assert.equal(group.name, 'Replacement group');
+  assert.equal(group.size, 3);
+  assert.deepEqual(group.created_at, new Date('2024-06-06T08:59:22.156Z'));
+  assert.deepEqual(group.modified_at, new Date('2024-08-21T09:39:36.679Z'));
+  assert.ok(group.child_groups);
+  assert.equal(group.child_groups[0], '01W4FFL35P4NC4K35SUBGROUP1');
+});
+
+When('I send a request to delete an SMS group', async () => {
+  deleteGroupResponse = await groupsApi.delete({
+    group_id: '01W4FFL35P4NC4K35SMSGROUP1',
+  });
+});
+
+Then('the delete SMS group response contains no data', () => {
+  assert.deepEqual(deleteGroupResponse, {} );
+});
+
+When('I send a request to list the members of an SMS group', async () => {
+  phoneNumbersList = await groupsApi.listMembers({
+    group_id: '01W4FFL35P4NC4K35SMSGROUP1',
+  });
+});
+
+Then('the response contains the phone numbers of the SMS group', () => {
+  assert.ok(phoneNumbersList);
+  assert.equal(phoneNumbersList[0], '12018881111');
+  assert.equal(phoneNumbersList[1], '12018882222');
+  assert.equal(phoneNumbersList[2], '12018883333');
+});


### PR DESCRIPTION
Notice: breaking change in the interface names:
 - `CreateGroupResponse` / `ReplaceGroupResponse` / `UpdateGroupResponse` / `GroupResponse` have all disappeared to become a single `Group` interface to reduce the confusion when using a response object from the SMS groups endpoints.