### PR TITLE
DEVEXP-585: Backward compatible fixes

### DIFF
--- a/examples/webhooks/src/services/verification-event.service.ts
+++ b/examples/webhooks/src/services/verification-event.service.ts
@@ -29,7 +29,7 @@ export class VerificationEventService {
         res.status(200).json(smsRequestEventResponse);
         break;
       case 'callout':
-        const calloutRequestEventResponse: Verification.CalloutRequestEventResponse = {
+        const calloutRequestEventResponse: Verification.PhoneCallRequestEventResponse = {
           action: 'allow',
           callout: {
             code: '123456',

--- a/packages/conversation/CHANGELOG.md
+++ b/packages/conversation/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Version 1.2.0
+- [Tech] Update dependency `@sinch/sdk-client` to `1.2.0`.
+- [Bugfix] Fix issue with pagination to iterate over multiple pages.
+- [Bugfix] `ListConversationsRequestData`: the property `only_active` becomes optional.
+- [Bugfix] Template V2: add an optional `id` property to the `V2Template` interface.
+- [Bugfix] `conversations.listRecent()`: Add a page_size value by default. Without it the API returns an empty list.
+- [Bugfix][Breaking] `InjectConversationEvent` interface: only `AppEvent` is allowed (`ContactEvent` and `ContactMessageEvent` are no longer allowed).
+- [Bugfix][Breaking TS] 
+  - Template V2: For "create" and "update" operations, the request bodies interface no longer accept read-only properties.
+  - Webhooks: For "create" and "update" operations, the request bodies interface no longer accept read-only properties.
+- [E2E] Add Cucumber steps implementation.
+
 ## Version 1.1.0
 - [Tech] Update dependency `@sinch/sdk-client` to `1.1.0`
 

--- a/packages/conversation/CHANGELOG.md
+++ b/packages/conversation/CHANGELOG.md
@@ -5,7 +5,7 @@
 - [Bugfix] Template V2: add an optional `id` property to the `V2Template` interface.
 - [Bugfix] `conversations.listRecent()`: Add a page_size value by default. Without it the API returns an empty list.
 - [Bugfix][Breaking] `InjectConversationEvent` interface: only `AppEvent` is allowed (`ContactEvent` and `ContactMessageEvent` are no longer allowed).
-- [Bugfix][Breaking TS] 
+- [Bugfix][Breaking]
   - Template V2: For "create" and "update" operations, the request bodies interface no longer accept read-only properties.
   - Webhooks: For "create" and "update" operations, the request bodies interface no longer accept read-only properties.
 - [E2E] Add Cucumber steps implementation.

--- a/packages/conversation/src/models/v1/conversation/conversation.ts
+++ b/packages/conversation/src/models/v1/conversation/conversation.ts
@@ -20,8 +20,7 @@ export interface Conversation {
   /**
    * Arbitrary data set by the Conversation API clients. Up to 1024 characters long.
    * NOTE: This field has been deprecated due to changes in the system architecture or functionality.
-   * It is no longer actively maintained and may be removed in future versions. Please avoid relying on this field in new code.
-   * @deprecated
+   * @deprecated It is no longer actively maintained and may be removed in future versions. Please avoid relying on this field in new code.
    */
   metadata?: string;
   /** Arbitrary data set by the Conversation API clients and/or provided in the `conversation_metadata` field of a SendMessageRequest. A valid JSON object. */

--- a/packages/elastic-sip-trunking/CHANGELOG.md
+++ b/packages/elastic-sip-trunking/CHANGELOG.md
@@ -2,10 +2,10 @@
 - [Tech] Update dependency `@sinch/sdk-client` to `1.2.0`.
 - [Feature] Add the method `accessControlList.get()`.
 - Calls History:
-  - [Bugfix][Breaking TS] The `DirectionEnum` values are in lower case. E.g: INBOUND -> inbound.
-  - [Bugfix][Breaking TS] The price `amount` is now a `number` instead of a `string`.
+  - [Bugfix][Breaking] The `DirectionEnum` values are in lower case. E.g: INBOUND -> inbound.
+  - [Bugfix][Breaking] The price `amount` is now a `number` instead of a `string`.
   - [Feature] Support date range filter for listing calls.
-- [Bugfix][Breaking TS]
+- [Bugfix][Breaking]
   - ACLs: For "create", "update" and "addIPRange" operations, the request bodies interface no longer accept read-only properties.
   - SIP endpoints: For "create" and "update" operations, the request bodies interface no longer accept read-only properties.
   - SIP Trunks: For "create" and "update" operations, the request bodies interface no longer accept read-only properties.

--- a/packages/elastic-sip-trunking/CHANGELOG.md
+++ b/packages/elastic-sip-trunking/CHANGELOG.md
@@ -1,3 +1,16 @@
+## Version 1.2.0
+- [Tech] Update dependency `@sinch/sdk-client` to `1.2.0`.
+- [Feature] Add the method `accessControlList.get()`.
+- Calls History:
+  - [Bugfix][Breaking TS] The `DirectionEnum` values are in lower case. E.g: INBOUND -> inbound.
+  - [Bugfix][Breaking TS] The price `amount` is now a `number` instead of a `string`.
+  - [Feature] Support date range filter for listing calls.
+- [Bugfix][Breaking TS]
+  - ACLs: For "create", "update" and "addIPRange" operations, the request bodies interface no longer accept read-only properties.
+  - SIP endpoints: For "create" and "update" operations, the request bodies interface no longer accept read-only properties.
+  - SIP Trunks: For "create" and "update" operations, the request bodies interface no longer accept read-only properties.
+- [E2E] Add Cucumber steps implementation.
+
 # Version 1.1.0
  - Initial version. Support for:
    - SIP Trunks

--- a/packages/fax/CHANGELOG.md
+++ b/packages/fax/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Version 1.2.0
+- [Tech] Update dependency `@sinch/sdk-client` to `1.2.0`.
+- [Feature] Support date range filter for listing faxes.
+- [Feature] Add `emails.listForNumber()` method (identical to `services.listEmailsForNumber()`).
+- [Bugfix] Fix `faxes.send()` to send one or several faxes over JSON or FormData. Add examples in the [simple-examples](https://github.com/sinch/sinch-sdk-node/tree/main/examples/simple-examples/src/fax/faxes) package.
+- [Feature][Breaking] Update interfaces according to OAS updates.
+- [E2E] Add Cucumber steps implementation.
+
 ## Version 1.1.0
 - [Tech] Update dependency `@sinch/sdk-client` to `1.1.0`
 
@@ -6,7 +14,7 @@
 
 ## Version 0.0.5
 - [Tech] Update dependency `@sinch/sdk-client` to `0.0.5`
-- [Tech][Breaking] Export all model interfaces under the namespace `Fax`
+- [Tech][Breaking TS] Export all model interfaces under the namespace `Fax`
 - [Bugfix] Fix pagination
 - [Bugfix] Fix content format sent when using `multipart/form-data`: boolean is not allowed
 - [Feature] Support hostname override

--- a/packages/numbers/CHANGELOG.md
+++ b/packages/numbers/CHANGELOG.md
@@ -3,27 +3,17 @@
 - [Deprecation notice] `availableNumber` and `activeNumber` subdomain are deprecated and all methods are now defined on the upper numbers service.
    All the methods names are the same except `availableNumber.list()` -> `searchForAvailableNumbers()`
 
-```typescript
-// Deprecated
-numbersService.availableNumber.checkAvailability();
-numbersService.availableNumber.list();
-numbersService.availableNumber.rent();
-numbersService.availableNumber.rentAny();
-numbersService.activeNumber.get();
-numbersService.activeNumber.list();
-numbersService.activeNumber.update();
-numbersService.activeNumber.release();
+| Deprecated                                           | New                                          |
+|------------------------------------------------------|----------------------------------------------|
+| `numbersService.availableNumber.checkAvailability()` | `numbersService.checkAvailability()`         |
+| `numbersService.availableNumber.list()`              | `numbersService.searchForAvailableNumbers()` |
+| `numbersService.availableNumber.rent()`              | `numbersService.rent()`                      |
+| `numbersService.availableNumber.rentAny()`           | `numbersService.rentAny()`                   |
+| `numbersService.activeNumber.get()`                  | `numbersService.get()`                       |
+| `numbersService.activeNumber.list()`                 | `numbersService.list()`                      |
+| `numbersService.activeNumber.update()`               | `numbersService.update()`                    |
+| `numbersService.activeNumber.release()`              | `numbersService.release()`                   |
 
-// New
-numbersService.checkAvailability();
-numbersService.searchForAvailableNumbers(); // Mind the function name change
-numbersService.rent();
-numbersService.rentAny();
-numbersService.get();
-numbersService.list();
-numbersService.update();
-numbersService.release();
-```
 - [E2E] Add Cucumber steps implementation.
 
 ## Version 1.1.0

--- a/packages/numbers/CHANGELOG.md
+++ b/packages/numbers/CHANGELOG.md
@@ -1,3 +1,31 @@
+## Version 1.2.0
+- [Tech] Update dependency `@sinch/sdk-client` to `1.2.0`.
+- [Deprecation notice] `availableNumber` and `activeNumber` subdomain are deprecated and all methods are now defined on the upper numbers service.
+   All the methods names are the same except `availableNumber.list()` -> `searchForAvailableNumbers()`
+
+```typescript
+// Deprecated
+numbersService.availableNumber.checkAvailability();
+numbersService.availableNumber.list();
+numbersService.availableNumber.rent();
+numbersService.availableNumber.rentAny();
+numbersService.activeNumber.get();
+numbersService.activeNumber.list();
+numbersService.activeNumber.update();
+numbersService.activeNumber.release();
+
+// New
+numbersService.checkAvailability();
+numbersService.searchForAvailableNumbers(); // Mind the function name change
+numbersService.rent();
+numbersService.rentAny();
+numbersService.get();
+numbersService.list();
+numbersService.update();
+numbersService.release();
+```
+- [E2E] Add Cucumber steps implementation.
+
 ## Version 1.1.0
 - [Tech] Update dependency `@sinch/sdk-client` to `1.1.0`
 - [Feature] Update voiceConfiguration object to support Fax and EST configuration properties

--- a/packages/numbers/src/rest/v1/numbers-service.ts
+++ b/packages/numbers/src/rest/v1/numbers-service.ts
@@ -27,9 +27,9 @@ import {
 export class NumbersService {
   public readonly availableRegions: AvailableRegionsApi;
   public readonly callbacks: CallbacksApi;
-  /** @deprecated use the methods exposed at the Numbers Service level instead */
+  /** @deprecated Use the methods exposed at the Numbers Service level instead */
   public readonly availableNumber: AvailableNumberApi;
-  /** @deprecated use the methods exposed at the Numbers Service level instead */
+  /** @deprecated Use the methods exposed at the Numbers Service level instead */
   public readonly activeNumber: ActiveNumberApi;
 
   /**

--- a/packages/sdk-client/CHANGELOG.md
+++ b/packages/sdk-client/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 1.2.0
+- [Feature] Support a new mode of pagination to support the Conversation API.
+- [Feature] Remove the `TimezoneResponse` plugin and autocorrect the timezones when reviving the dates in the API responses.
+- [Feature] Add utility methods to support the dateRange filters for EST and Fax APIs.
+- [Bugfix] Handle HTTP status 202 in the `ExceptionResponse` plugin.
+
 ## Version 1.1.0
 - [Feature] Add new pagination type support specific to EST
 

--- a/packages/sdk-core/CHANGELOG.md
+++ b/packages/sdk-core/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Version 1.2.0
+- Update dependency `@sinch/numbers` to version `1.2.0`
+- Update dependency `@sinch/sms` to version `1.2.0`
+- Update dependency `@sinch/verification` to version `1.2.0`
+- Update dependency `@sinch/voice` to version `1.2.0`
+- Update dependency `@sinch/conversation` to version `1.2.0`
+- Update dependency `@sinch/fax` to version `1.2.0`
+- Update dependency `@sinch/elastic-sip-trunking` to version `1.2.0`
+
 ## Version 1.1.0
 - Update dependency `@sinch/numbers` to version `1.1.0`
 - Update dependency `@sinch/sms` to version `1.1.0`

--- a/packages/sms/CHANGELOG.md
+++ b/packages/sms/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Version 1.2.0
+- [Tech] Update dependency `@sinch/sdk-client` to `1.2.0`.
+- [Feature] Align "Dry Run" response interface with OAS update: `message_part?: string` becomes `number_of_parts?: number`.
+- [Feature] In the interface `MessageDeliveryStatus`, the property `recipients` becomes optional.
+- [Feature] In the interface `GetDeliveryReportByBatchIdRequestData`, the property `code` can also be a `number` or a `number[]` on top of a `string`.
+- [Feature] In the interface `ListInboundMessagesRequestData`, the property `to` can also be a `string[]` on top of a `string`.
+- [Bugfix] Remove default values set by the SDK when forging the API request.
+- [Bugfix] In the interface `UpdateGroupRequest`, the property `name` can also be set to null to remove an existing name set.
+- [Deprecation Notice] All variations of a group response (`GroupResponse`, `CreateGroupResponse`, `ReplaceGroupResponse` and `UpdateGroupResponse`) are deprecated and replaced by the unique interface `Group`.
+- [Deprecation Notice] In the interface `GetDeliveryReportByPhoneNumberRequestData`, the request parameter `recipient_msisdn` is deprecated and should be replaced by `phone_number`.
+- [E2E] Add Cucumber steps implementation.
+
 ## Version 1.1.0
 - [Tech] Update dependency `@sinch/sdk-client` to `1.1.0`
 

--- a/packages/sms/src/models/v1/group/group.ts
+++ b/packages/sms/src/models/v1/group/group.ts
@@ -1,5 +1,17 @@
 import { GroupAutoUpdate } from '../group-auto-update';
 
+/** @deprecated Use Group instead */
+export type CreateGroupResponse = Group;
+
+/** @deprecated Use Group instead */
+export type GroupResponse = Group;
+
+/** @deprecated Use Group instead */
+export type ReplaceGroupResponse = Group;
+
+/** @deprecated Use Group instead */
+export type UpdateGroupResponse = Group;
+
 export interface Group {
 
   /** The ID used to reference this group. */

--- a/packages/sms/src/models/v1/group/index.ts
+++ b/packages/sms/src/models/v1/group/index.ts
@@ -1,1 +1,1 @@
-export type { Group } from './group';
+export type { Group, GroupResponse, CreateGroupResponse, ReplaceGroupResponse, UpdateGroupResponse } from './group';

--- a/packages/sms/src/models/v1/requests/delivery-reports/delivery-reports-request-data.ts
+++ b/packages/sms/src/models/v1/requests/delivery-reports/delivery-reports-request-data.ts
@@ -10,12 +10,28 @@ export interface GetDeliveryReportByBatchIdRequestData {
   /** Comma separated list of delivery_receipt_error_codes to include */
   'code'?: string | number | number[];
 }
-export interface GetDeliveryReportByPhoneNumberRequestData {
+
+export type GetDeliveryReportByPhoneNumberRequestData =
+  GetDeliveryReportByPhoneNumberRequestDataBC | GetDeliveryReportByPhoneNumberRequestDataDeprecated;
+
+export interface GetDeliveryReportByPhoneNumberRequestDataBC {
   /** The batch ID you received from sending a message. */
   'batch_id': string;
   /** Phone number for which you to want to search. */
   'phone_number': string;
+  /** @deprecated Use phone_number instead */
+  recipient_msisdn?: never;
 }
+
+export interface GetDeliveryReportByPhoneNumberRequestDataDeprecated {
+  /** The batch ID you received from sending a message. */
+  'batch_id': string;
+  /** @deprecated: use phone_number instead */
+  recipient_msisdn: string;
+  /** Phone number for which you to want to search. */
+  phone_number?: never;
+}
+
 export interface ListDeliveryReportsRequestData {
   /** The page number starting from 0. */
   'page'?: number;

--- a/packages/sms/src/rest/v1/delivery-reports/delivery-reports-api.ts
+++ b/packages/sms/src/rest/v1/delivery-reports/delivery-reports-api.ts
@@ -71,8 +71,17 @@ export class DeliveryReportsApi extends SmsDomainApi {
       'Accept': 'application/json',
     };
 
+    // TODO: Remove in v2.0
+    let phoneNumber;
+    if (data['phone_number']) {
+      phoneNumber = data['phone_number'];
+    }
+    else if (data['recipient_msisdn']) {
+      phoneNumber = data['recipient_msisdn'];
+    }
+
     const body: RequestBody = '';
-    const basePathUrl = `${this.client.apiClientOptions.hostname}/xms/v1/${this.client.apiClientOptions.projectId}/batches/${data['batch_id']}/delivery_report/${data['phone_number']}`;
+    const basePathUrl = `${this.client.apiClientOptions.hostname}/xms/v1/${this.client.apiClientOptions.projectId}/batches/${data['batch_id']}/delivery_report/${phoneNumber}`;
 
     const requestOptions
       = await this.client.prepareOptions(basePathUrl, 'GET', getParams, headers, body || undefined);

--- a/packages/verification/CHANGELOG.md
+++ b/packages/verification/CHANGELOG.md
@@ -49,17 +49,11 @@
 | SMSVerificationReportResponse | SmsVerificationReportResponse |
 
 - [Deprecation Notice] The type `VerificationCallback` becomes `VerificationCallbackEvent` and is accessible on the `Verification` namespace.
-```typescript
-// Deprecated
-handleEvent(event: VerificationCallback, res: Response) {
-  console.log(event);
-}
 
-// New
-handleEvent(event: Verification.VerificationCallbackEvent, res: Response) {
-  console.log(event);
-}
-```
+| Deprecated                                                                                                                  | New                                                                                                                                           |
+|-----------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| <pre><code>handleEvent(event: VerificationCallback, res: Response) {<br/>&nbsp;&nbsp;console.log(event);<br/>}</code></pre> | <pre><code>handleEvent(event: Verification.VerificationCallbackEvent, res: Response) {<br/>&nbsp;&nbsp;console.log(event);<br/>}</code></pre> |
+
 - [Deprecation Notice] The type `TypeEnum` should be replaced with the type `IdentityType`.
 - [Deprecation Notice] The type `FlashCallContent` should be replaced with the type `FlashCallProperties`.
 - [Deprecation Notice] The type `SmsContent` should be replaced with the type `SmsProperties`.

--- a/packages/verification/CHANGELOG.md
+++ b/packages/verification/CHANGELOG.md
@@ -1,3 +1,70 @@
+## Version 1.2.0
+- [Tech] Update dependency `@sinch/sdk-client` to `1.2.0`.
+- [Feature] Support the `locale` parameter in the `SmsOptions` interface.
+- [Deprecation Notice] In the interface `VerificationStatusByIdentityRequestData`, the property `method` supports ‘flashcall’ on top of ‘flashCall’.
+- [Deprecation Notice] All the references to "callout" and "seamless" will be replaced by "phoneCall" and "data" respectively.
+  - In the interface `VerificationStatusByIdentityRequestData`, the property `method` supports ‘phonecall’ on top of ‘callout’.
+  - API methods:
+  
+| Deprecated                                | New                                         |
+|-------------------------------------------|---------------------------------------------|
+| `verifications.startCallout()`            | `verifications.startPhoneCall()`            |
+| `verifications.reportCalloutById()`       | `verifications.reportPhoneCallById()`       |
+| `verifications.reportCalloutByIdentity()` | `verifications.reportPhoneCallByIdentity()` |
+- 
+  - Helpers:
+
+| Deprecated                                                 | New                                               |
+|------------------------------------------------------------|---------------------------------------------------|
+| `startVerificationHelper.buildCalloutRequest()`            | `startVerificationHelper.buildPhoneCallRequest()` |
+| `startVerificationHelper.buildSeamlessRequest()`           | `startVerificationHelper.buildDataRequest()`      |
+| `reportVerificationByIdHelper.buildCalloutRequest()`       | `startVerificationHelper.buildPhoneCallRequest()` |
+| `reportVerificationByIdentityHelper.buildCalloutRequest()` | `startVerificationHelper.buildPhoneCallRequest()` |
+-
+  - Interfaces
+
+| Deprecated                                                                                                                                                                       | New                                                                                                                                                                                    |
+|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <pre><code>StartCalloutVerificationRequestData {<br/>&nbsp;&nbsp;startVerificationWithCalloutRequestBody: StartVerificationWithCallout;<br/>}</code></pre>                       | <pre><code>StartPhoneCallVerificationRequestData {<br/>&nbsp;&nbsp;startVerificationWithPhoneCallRequestBody: StartVerificationWithPhoneCall;<br/>}</code></pre>                       |
+| <pre><code>StartSeamlessVerificationRequestData {<br/>&nbsp;&nbsp;startSeamlessVerificationRequestBody: StartSeamlessVerification;<br/>}</code></pre>                            | <pre><code>StartDataVerificationRequestData {<br/>&nbsp;&nbsp;startDataVerificationRequestBody: StartDataVerification;<br/>}</code></pre>                                              |
+| <pre><code>ReportCalloutVerificationByIdRequestData {<br/>&nbsp;&nbsp;reportCalloutVerificationByIdentityRequestBody: CalloutVerificationReportRequest;<br/>}</code></pre>       | <pre><code>ReportPhoneCallVerificationByIdRequestData {<br/>&nbsp;&nbsp;reportPhoneCallVerificationByIdRequestBody: PhoneCallVerificationReportRequest;<br/>}</code></pre>             |
+| <pre><code>ReportCalloutVerificationByIdentityRequestData {<br/>&nbsp;&nbsp;reportCalloutVerificationByIdentityRequestBody: CalloutVerificationReportRequest;<br/>}</code></pre> | <pre><code>ReportPhoneCallVerificationByIdentityRequestData {<br/>&nbsp;&nbsp;reportPhoneCallVerificationByIdentityRequestBody: PhoneCallVerificationReportRequest;<br/>}</code></pre> |
+| <pre><code>StartVerificationWithCallout {<br/>&nbsp;&nbsp;calloutOptions: CalloutOptions;<br/>}</code></pre>                                                                     | <pre><code>StartVerificationWithPhoneCall {<br/>&nbsp;&nbsp;phoneCallOptions: PhoneCallOptions;<br/>}</code></pre>                                                                     |
+| `StartSeamlessVerification`                                                                                                                                                      | `StartDataVerification`                                                                                                                                                                | 
+| `CalloutOptions`                                                                                                                                                                 | `PhoneCallOptions`                                                                                                                                                                     |
+| `CalloutOptionsSpeech`                                                                                                                                                           | `PhoneCallOptionsSpeech`                                                                                                                                                               |
+| `CalloutVerificationStatusResponse`                                                                                                                                              | `PhoneCallVerificationStatusResponse`                                                                                                                                                  |
+| `CalloutVerificationReportResponse`                                                                                                                                              | `PhoneCallVerificationReportResponse`                                                                                                                                                  |
+| `StartCalloutVerificationResponse`                                                                                                                                               | `StartPhoneCallVerificationResponse`                                                                                                                                                   |
+| `CalloutRequestEventResponse`                                                                                                                                                    | `PhoneCallRequestEventResponse`                                                                                                                                                        |
+| `CalloutProperties`                                                                                                                                                              | `PhoneCallProperties`                                                                                                                                                                  |
+| `CalloutContent`                                                                                                                                                                 | `PhoneCallContent`                                                                                                                                                                     |
+- [Deprecation Notice] The interfaces containing `SMS` in uppercase will be replaced with the same name but with `Sms` in PascaleCase:
+
+| Deprecated                    | New                           |
+|-------------------------------|-------------------------------|
+| VerificationPriceSMS          | VerificationPriceSms          |
+| SMSRequestEventResponse       | SmsRequestEventResponse       |
+| SMSVerificationStatusResponse | SmsVerificationStatusResponse |
+| SMSVerificationReportResponse | SmsVerificationReportResponse |
+
+- [Deprecation Notice] The type `VerificationCallback` becomes `VerificationCallbackEvent` and is accessible on the `Verification` namespace.
+```typescript
+// Deprecated
+handleEvent(event: VerificationCallback, res: Response) {
+  console.log(event);
+}
+
+// New
+handleEvent(event: Verification.VerificationCallbackEvent, res: Response) {
+  console.log(event);
+}
+```
+- [Deprecation Notice] The type `TypeEnum` should be replaced with the type `IdentityType`.
+- [Deprecation Notice] The type `FlashCallContent` should be replaced with the type `FlashCallProperties`.
+- [Deprecation Notice] The type `SmsContent` should be replaced with the type `SmsProperties`.
+- [E2E] Add Cucumber steps implementation.
+
 ## Version 1.1.0
 - [Tech] Update dependency `@sinch/sdk-client` to `1.1.0`
 

--- a/packages/verification/src/models/v1/helper.ts
+++ b/packages/verification/src/models/v1/helper.ts
@@ -82,7 +82,8 @@ export const startVerificationHelper = {
    * @param {string} [reference] - An optional reference identifier for the callout.
    * @param {string} [locale] - An optional locale string to specify the language or region for the callout.
    * @return {StartCalloutVerificationRequestData} The constructed callout request object.
-   * @deprecated */
+   * @deprecated Use the method buildPhoneCallRequest() instead
+   */
   buildCalloutRequest: (
     phoneNumber: string,
     reference?: string,
@@ -160,7 +161,7 @@ export const startVerificationHelper = {
    * @param {string} phoneNumber - The phone number to verify.
    * @param {string} [reference] - An optional reference identifier for the verification request.
    * @return {StartSeamlessVerificationRequestData} The constructed seamless verification request data.
-   * @deprecated
+   * @deprecated Use the method buildDataRequest() instead
    */
   buildSeamlessRequest: (
     phoneNumber: string,
@@ -227,7 +228,7 @@ export const reportVerificationByIdHelper = {
    * @param {string} id - The unique identifier for the callout verification request.
    * @param {string} code - The verification code received during the callout.
    * @return {ReportCalloutVerificationByIdRequestData} The request data object used to report the callout verification.
-   * @deprecated
+   * @deprecated Use the method buildPhoneCallRequest() instead
    */
   buildCalloutRequest: (
     id: string,
@@ -313,7 +314,7 @@ export const reportVerificationByIdentityHelper = {
    * @param {string} identity - The phone number for which the callout verification process has been initiated.
    * @param {string} code - The verification code received during the callout.
    * @return {ReportCalloutVerificationByIdentityRequestData} The request data object used to report the callout verification.
-   * @deprecated
+   * @deprecated Use the method buildPhoneCallRequest() instead
    */
   buildCalloutRequest: (
     identity: string,

--- a/packages/verification/src/models/v1/identity/identity.ts
+++ b/packages/verification/src/models/v1/identity/identity.ts
@@ -4,7 +4,12 @@
 export interface Identity {
 
   /** Currently only `number` type is supported. */
-  type: 'number';
+  type: IdentityType;
   /** For type `number` use an [E.164](https://community.sinch.com/t5/Glossary/E-164/ta-p/7537)-compatible phone number. */
   endpoint: string;
 }
+
+export type IdentityType = 'number';
+
+/** @deprecated Use IdentityType instead */
+export type TypeEnum = IdentityType;

--- a/packages/verification/src/models/v1/identity/index.ts
+++ b/packages/verification/src/models/v1/identity/index.ts
@@ -1,1 +1,1 @@
-export type { Identity } from './identity';
+export type { Identity, IdentityType, TypeEnum } from './identity';

--- a/packages/verification/src/models/v1/mod-callbacks/callout-request-event-response/index.ts
+++ b/packages/verification/src/models/v1/mod-callbacks/callout-request-event-response/index.ts
@@ -1,5 +1,0 @@
-export type {
-  CalloutRequestEventResponse,
-  CalloutProperties,
-  SpeechProperties,
-} from './callout-request-event-response';

--- a/packages/verification/src/models/v1/mod-callbacks/flashcall-request-event-response/flashcall-request-event-response.ts
+++ b/packages/verification/src/models/v1/mod-callbacks/flashcall-request-event-response/flashcall-request-event-response.ts
@@ -7,7 +7,10 @@ export interface FlashCallRequestEventResponse {
   flashCall?: FlashCallProperties;
 }
 
-interface FlashCallProperties {
+/** @deprecated Use FlashCallProperties instead */
+export type FlashCallContent = FlashCallProperties;
+
+export interface FlashCallProperties {
   /** The phone number that will be displayed to the user when the flashcall is received on the user\'s phone. By default, the Sinch dashboard will randomly select the CLI that will be displayed during a flashcall from a pool of numbers. If you want to set your own CLI, you can specify it in the response to the Verification Request Event. */
   cli?: string;
   /** The maximum time that a flashcall verification will be active and can be completed. If the phone number hasn\'t been verified successfully during this time, then the verification request will fail. By default, the Sinch dashboard will automatically optimize dial time out during a flashcall. If you want to set your own dial time out for the flashcall, you can specify it in the response to the Verification Request Event. */

--- a/packages/verification/src/models/v1/mod-callbacks/flashcall-request-event-response/index.ts
+++ b/packages/verification/src/models/v1/mod-callbacks/flashcall-request-event-response/index.ts
@@ -1,1 +1,5 @@
-export type { FlashCallRequestEventResponse } from './flashcall-request-event-response';
+export type {
+  FlashCallRequestEventResponse,
+  FlashCallContent,
+  FlashCallProperties,
+} from './flashcall-request-event-response';

--- a/packages/verification/src/models/v1/mod-callbacks/index.ts
+++ b/packages/verification/src/models/v1/mod-callbacks/index.ts
@@ -2,7 +2,7 @@ export * from './verification-callback-event';
 // 'Verification Request Event' received from Sinch server
 export * from './verification-request-event';
 // Response to send to Sinch server for a 'Verification Request Event'
-export * from './callout-request-event-response';
+export * from './phonecall-request-event-response';
 export * from './flashcall-request-event-response';
 export * from './sms-request-event-response';
 export * from './verification-request-event-response';

--- a/packages/verification/src/models/v1/mod-callbacks/phonecall-request-event-response/index.ts
+++ b/packages/verification/src/models/v1/mod-callbacks/phonecall-request-event-response/index.ts
@@ -1,0 +1,7 @@
+export type {
+  CalloutRequestEventResponse,
+  PhoneCallRequestEventResponse,
+  CalloutProperties,
+  PhoneCallProperties,
+  SpeechProperties,
+} from './phonecall-request-event-response';

--- a/packages/verification/src/models/v1/mod-callbacks/phonecall-request-event-response/phonecall-request-event-response.ts
+++ b/packages/verification/src/models/v1/mod-callbacks/phonecall-request-event-response/phonecall-request-event-response.ts
@@ -1,13 +1,19 @@
 import { ActionEnum } from '../../enums';
 
-export interface CalloutRequestEventResponse {
+/** @deprecated Use PhoneCallRequestEventResponse instead */
+export type CalloutRequestEventResponse = PhoneCallRequestEventResponse;
+
+export interface PhoneCallRequestEventResponse {
   /** Determines whether the verification can be executed. */
   action?: ActionEnum;
-  /** @see CalloutProperties */
-  callout?: CalloutProperties;
+  /** @see PhoneCallProperties */
+  callout?: PhoneCallProperties;
 }
 
-export interface CalloutProperties {
+/** @deprecated Use PhoneCallProperties instead */
+export type CalloutProperties = PhoneCallProperties;
+
+export interface PhoneCallProperties {
   /** The Phone Call PIN that should be entered by the user. Sinch servers automatically generate PIN codes for Phone Call verification. If you want to set your own code, you can specify it in the response to the Verification Request Event. */
   code?: string;
   /** @see SpeechProperties */

--- a/packages/verification/src/models/v1/mod-callbacks/sms-request-event-response/index.ts
+++ b/packages/verification/src/models/v1/mod-callbacks/sms-request-event-response/index.ts
@@ -1,1 +1,6 @@
-export type { SmsRequestEventResponse } from './sms-request-event-response';
+export type {
+  SMSRequestEventResponse,
+  SmsRequestEventResponse,
+  SmsContent,
+  SmsProperties,
+} from './sms-request-event-response';

--- a/packages/verification/src/models/v1/mod-callbacks/sms-request-event-response/sms-request-event-response.ts
+++ b/packages/verification/src/models/v1/mod-callbacks/sms-request-event-response/sms-request-event-response.ts
@@ -7,9 +7,15 @@ export interface SmsRequestEventResponse {
   sms?: SmsProperties;
 }
 
-interface SmsProperties {
+export interface SmsProperties {
   /** The SMS PIN that should be used. By default, the Sinch dashboard will automatically generate PIN codes for SMS verification. If you want to set your own PIN, you can specify it in the response to the Verification Request Event. */
   code?: string;
   /** List of strings */
   acceptLanguage?: string[];
 }
+
+/** @deprecated Use SmsRequestEventResponse instead */
+export type SMSRequestEventResponse = SmsRequestEventResponse;
+
+/** @deprecated Use SmsProperties instead */
+export type SmsContent = SmsProperties;

--- a/packages/verification/src/models/v1/mod-callbacks/verification-request-event-response/verification-request-event-response.ts
+++ b/packages/verification/src/models/v1/mod-callbacks/verification-request-event-response/verification-request-event-response.ts
@@ -1,6 +1,6 @@
 import { SmsRequestEventResponse } from '../sms-request-event-response';
 import { FlashCallRequestEventResponse } from '../flashcall-request-event-response';
-import { CalloutRequestEventResponse } from '../callout-request-event-response';
+import { CalloutRequestEventResponse } from '../phonecall-request-event-response';
 
 export type VerificationRequestEventResponse = SmsRequestEventResponse
   | FlashCallRequestEventResponse

--- a/packages/verification/src/models/v1/mod-callbacks/verification-result-event-response/verification-result-event-response.ts
+++ b/packages/verification/src/models/v1/mod-callbacks/verification-result-event-response/verification-result-event-response.ts
@@ -1,6 +1,6 @@
 import { SmsRequestEventResponse } from '../sms-request-event-response';
 import { FlashCallRequestEventResponse } from '../flashcall-request-event-response';
-import { CalloutRequestEventResponse } from '../callout-request-event-response';
+import { CalloutRequestEventResponse } from '../phonecall-request-event-response';
 
 export type VerificationResultEventResponse = SmsRequestEventResponse
   | FlashCallRequestEventResponse

--- a/packages/verification/src/models/v1/phonecall-verification-report-response/phonecall-verification-report-response.ts
+++ b/packages/verification/src/models/v1/phonecall-verification-report-response/phonecall-verification-report-response.ts
@@ -1,7 +1,7 @@
 import { ReasonEnum, SourceEnum, VerificationStatusEnum } from '../enums';
 import { Identity } from '../identity';
 
-/** @deprecated */
+/** @deprecated Use PhoneCallVerificationReportResponse instead */
 export type CalloutVerificationReportResponse = PhoneCallVerificationReportResponse;
 
 export interface PhoneCallVerificationReportResponse {

--- a/packages/verification/src/models/v1/phonecall-verification-status-response/phonecall-verification-status-response.ts
+++ b/packages/verification/src/models/v1/phonecall-verification-status-response/phonecall-verification-status-response.ts
@@ -2,7 +2,7 @@ import { CallResult, ReasonEnum, VerificationStatusEnum } from '../enums';
 import { Identity } from '../identity';
 import { VerificationPriceCall } from '../verification-price-call';
 
-/** @deprecated */
+/** @deprecated Use PhoneCallVerificationStatusResponse instead  */
 export type CalloutVerificationStatusResponse = PhoneCallVerificationStatusResponse;
 
 export interface PhoneCallVerificationStatusResponse {

--- a/packages/verification/src/models/v1/requests/verification-status/verification-status-request-data.ts
+++ b/packages/verification/src/models/v1/requests/verification-status/verification-status-request-data.ts
@@ -6,8 +6,8 @@ export interface VerificationStatusByIdentityRequestData {
   /** For type `number` use a [E.164](https://community.sinch.com/t5/Glossary/E-164/ta-p/7537)-compatible phone number. */
   'endpoint': string;
   /** The method of the verification. */
-  // TODO v2.0 - Remove 'callout' option
-  'method': 'sms' | 'callout' | 'phonecall' | 'flashcall';
+  // TODO v2.0 - Remove 'callout' and 'flashCall' options
+  'method': 'sms' | 'callout' | 'phonecall' | 'flashCall' | 'flashcall';
 }
 export interface VerificationStatusByReferenceRequestData {
   /** The custom reference of the verification. */

--- a/packages/verification/src/models/v1/requests/verifications/verifications-request-data.ts
+++ b/packages/verification/src/models/v1/requests/verifications/verifications-request-data.ts
@@ -33,7 +33,7 @@ export interface ReportPhoneCallVerificationByIdRequestData extends ReportVerifi
   'reportPhoneCallVerificationByIdRequestBody': PhoneCallVerificationReportRequest;
 }
 
-/** @deprecated */
+/** @deprecated Use ReportPhoneCallVerificationByIdRequestData instead */
 export interface ReportCalloutVerificationByIdRequestData extends ReportVerificationByIdRequestDataBase {
   /** Request body to report a verification started with a callout by its ID */
   'reportCalloutVerificationByIdRequestBody': CalloutVerificationReportRequest;
@@ -59,7 +59,7 @@ export interface ReportPhoneCallVerificationByIdentityRequestData extends Report
   'reportPhoneCallVerificationByIdentityRequestBody': PhoneCallVerificationReportRequest;
 }
 
-/** @deprecated */
+/** @deprecated Use ReportPhoneCallVerificationByIdentityRequestData instead */
 export interface ReportCalloutVerificationByIdentityRequestData extends ReportVerificationByIdentityRequestDataBase {
   /** Request body to report a verification started with a callout by its identity */
   'reportCalloutVerificationByIdentityRequestBody': CalloutVerificationReportRequest;
@@ -76,21 +76,22 @@ export interface StartFlashCallVerificationRequestData {
 }
 
 export interface StartPhoneCallVerificationRequestData {
+  /** Request body to start a verification with a phone call */
   'startVerificationWithPhoneCallRequestBody': StartVerificationWithPhoneCall;
 }
 
-/** @deprecated */
+/** @deprecated Use StartPhoneCallVerificationRequestData instead */
 export interface StartCalloutVerificationRequestData {
   /** Request body to start a verification with a callout */
   'startVerificationWithCalloutRequestBody': StartVerificationWithCallout;
 }
 
 export interface StartDataVerificationRequestData {
-  /** Request body to start a seamless verification */
+  /** Request body to start a data verification */
   'startDataVerificationRequestBody': StartDataVerification;
 }
 
-/** @deprecated */
+/** @deprecated Use StartDataVerificationRequestData instead */
 export interface StartSeamlessVerificationRequestData {
   /** Request body to start a seamless verification */
   'startSeamlessVerificationRequestBody': StartSeamlessVerification;

--- a/packages/verification/src/models/v1/sms-verification-report-response/index.ts
+++ b/packages/verification/src/models/v1/sms-verification-report-response/index.ts
@@ -1,1 +1,1 @@
-export type { SmsVerificationReportResponse } from './sms-verification-report-response';
+export type { SMSVerificationReportResponse, SmsVerificationReportResponse } from './sms-verification-report-response';

--- a/packages/verification/src/models/v1/sms-verification-report-response/sms-verification-report-response.ts
+++ b/packages/verification/src/models/v1/sms-verification-report-response/sms-verification-report-response.ts
@@ -18,3 +18,6 @@ export interface SmsVerificationReportResponse {
   /** @see Identity */
   identity?: Identity;
 }
+
+/** @deprecated Use SmsVerificationReportResponse instead */
+export type SMSVerificationReportResponse = SmsVerificationReportResponse;

--- a/packages/verification/src/models/v1/sms-verification-status-response/index.ts
+++ b/packages/verification/src/models/v1/sms-verification-status-response/index.ts
@@ -1,1 +1,1 @@
-export * from './sms-verification-status-response';
+export type { SMSVerificationStatusResponse, SmsVerificationStatusResponse } from './sms-verification-status-response';

--- a/packages/verification/src/models/v1/sms-verification-status-response/sms-verification-status-response.ts
+++ b/packages/verification/src/models/v1/sms-verification-status-response/sms-verification-status-response.ts
@@ -25,3 +25,6 @@ export interface SmsVerificationStatusResponse {
   /** Free text that the client is sending, used to show if the call/SMS was intercepted or not. */
   source?: SourceEnum;
 }
+
+/** @deprecated Use SmsVerificationStatusResponse instead */
+export type SMSVerificationStatusResponse = SmsVerificationStatusResponse;

--- a/packages/verification/src/models/v1/start-data-verification-response/start-data-verification-response.ts
+++ b/packages/verification/src/models/v1/start-data-verification-response/start-data-verification-response.ts
@@ -1,6 +1,6 @@
 import { LinksObject } from '../links-object';
 
-/** @deprecated */
+/** @deprecated Use StartDataVerificationResponse instead */
 export type StartSeamlessVerificationResponse = StartDataVerificationResponse;
 
 export interface StartDataVerificationResponse {

--- a/packages/verification/src/models/v1/start-phonecall-verification-response/start-phonecall-verification-response.ts
+++ b/packages/verification/src/models/v1/start-phonecall-verification-response/start-phonecall-verification-response.ts
@@ -1,6 +1,6 @@
 import { LinksObject } from '../links-object';
 
-/** @deprecated */
+/** @deprecated Use StartPhoneCallVerificationResponse instead */
 export type StartCalloutVerificationResponse = StartPhoneCallVerificationResponse;
 
 export interface StartPhoneCallVerificationResponse {

--- a/packages/verification/src/models/v1/start-verification-request/start-verification-request.ts
+++ b/packages/verification/src/models/v1/start-verification-request/start-verification-request.ts
@@ -20,7 +20,7 @@ export interface StartVerificationWithPhoneCallServerModel extends StartVerifica
   calloutOptions?: PhoneCallOptions;
 }
 
-/** @deprecated */
+/** @deprecated Use StartVerificationWithPhoneCall instead */
 export interface StartVerificationWithCallout extends StartVerificationBase {
   /** @see CalloutOptions */
   calloutOptions?: CalloutOptions;
@@ -28,8 +28,8 @@ export interface StartVerificationWithCallout extends StartVerificationBase {
 
 export interface StartDataVerification extends StartVerificationBase {}
 
-/** @deprecated */
-export interface StartSeamlessVerification extends StartVerificationBase {}
+/** @deprecated Use StartDataVerification instead */
+export type StartSeamlessVerification = StartDataVerification;
 
 export interface StartVerificationBase {
   /** @see Identity */
@@ -64,7 +64,7 @@ export interface FlashCallOptions {
   dialTimeout?: number;
 }
 
-/** @deprecated */
+/** @deprecated Use PhoneCallOptions instead */
 export type CalloutOptions = PhoneCallOptions;
 
 /**
@@ -74,7 +74,7 @@ export interface PhoneCallOptions {
   /** @see PhoneCallOptionsSpeech */
   speech?: PhoneCallOptionsSpeech;
 }
-/** @deprecated */
+/** @deprecated Use PhoneCallOptionsSpeech instead */
 export type CalloutOptionsSpeech = PhoneCallOptionsSpeech;
 
 /**

--- a/packages/verification/src/models/v1/verification-price-sms/verification-price-sms.ts
+++ b/packages/verification/src/models/v1/verification-price-sms/verification-price-sms.ts
@@ -8,3 +8,6 @@ export interface VerificationPriceSms {
   /** The maximum price charged for this verification process.  This property will appear in the body of the response with a delay.  It will become visible only when the verification status is other than PENDING.  */
   verificationPrice?: Price;
 }
+
+/** @deprecated Use VerificationPriceSms instead */
+export type VerificationPriceSMS = VerificationPriceSms;

--- a/packages/verification/src/models/v1/verification-report-request/verification-report-request.ts
+++ b/packages/verification/src/models/v1/verification-report-request/verification-report-request.ts
@@ -30,7 +30,7 @@ export interface PhoneCallVerificationReportRequestServerModel {
   callout: PhoneCallContent;
 }
 
-/** @deprecated */
+/** @deprecated Use PhoneCallVerificationReportRequest instead */
 export interface CalloutVerificationReportRequest {
   /** A configuration object containing settings specific to Phone Call verifications */
   callout: CalloutContent;
@@ -41,5 +41,5 @@ interface PhoneCallContent {
   code?: string;
 }
 
-/** @deprecated */
+/** @deprecated Use PhoneCallContent instead */
 type CalloutContent = PhoneCallContent;

--- a/packages/verification/src/rest/v1/callbacks/callbacks-webhook.ts
+++ b/packages/verification/src/rest/v1/callbacks/callbacks-webhook.ts
@@ -2,7 +2,7 @@ import { VerificationCallbackEvent, VerificationRequestEvent, VerificationResult
 import { CallbackProcessor, SinchClientParameters, validateAuthenticationHeader } from '@sinch/sdk-client';
 import { IncomingHttpHeaders } from 'http';
 
-/** @deprecated - use Verification.VerificationCallback instead */
+/** @deprecated Use Verification.VerificationCallback instead */
 export type VerificationCallback = VerificationRequestEvent | VerificationResultEvent;
 
 export class VerificationCallbackWebhooks implements CallbackProcessor<VerificationCallbackEvent>{

--- a/packages/verification/src/rest/v1/verifications/verifications-api.ts
+++ b/packages/verification/src/rest/v1/verifications/verifications-api.ts
@@ -56,7 +56,7 @@ export class VerificationsApi extends VerificationDomainApi {
     (data.reportSmsVerificationByIdRequestBody as any).method = 'sms';
     const getParams = this.client.extractQueryParams<ReportSmsVerificationByIdRequestData>(data, [] as never[]);
     const headers: { [key: string]: string | undefined } = {
-      'Content-Type': 'application/json; charset=UTF-8',
+      'Content-Type': 'application/json',
       'Accept': 'application/json',
     };
 
@@ -92,7 +92,7 @@ export class VerificationsApi extends VerificationDomainApi {
       data,
       [] as never[]);
     const headers: { [key: string]: string | undefined } = {
-      'Content-Type': 'application/json; charset=UTF-8',
+      'Content-Type': 'application/json',
       'Accept': 'application/json',
     };
 
@@ -126,7 +126,7 @@ export class VerificationsApi extends VerificationDomainApi {
     (data.reportPhoneCallVerificationByIdRequestBody as any).method = 'callout';
     const getParams = this.client.extractQueryParams<ReportPhoneCallVerificationByIdRequestData>(data, [] as never[]);
     const headers: { [key: string]: string | undefined } = {
-      'Content-Type': 'application/json; charset=UTF-8',
+      'Content-Type': 'application/json',
       'Accept': 'application/json',
     };
 
@@ -166,7 +166,7 @@ export class VerificationsApi extends VerificationDomainApi {
    * Report a Callout verification with ID
    * Report the received verification code to verify it, using the Verification ID of the Verification request.
    * @param { ReportCalloutVerificationByIdRequestData } data - The data to provide to the API call.
-   * @deprecated
+   * @deprecated Use the method reportPhoneCallById() instead
    */
   public async reportCalloutById(
     data: ReportCalloutVerificationByIdRequestData,
@@ -175,7 +175,7 @@ export class VerificationsApi extends VerificationDomainApi {
     (data.reportCalloutVerificationByIdRequestBody as any).method = 'callout';
     const getParams = this.client.extractQueryParams<ReportCalloutVerificationByIdRequestData>(data, [] as never[]);
     const headers: { [key: string]: string | undefined } = {
-      'Content-Type': 'application/json; charset=UTF-8',
+      'Content-Type': 'application/json',
       'Accept': 'application/json',
     };
 
@@ -209,7 +209,7 @@ export class VerificationsApi extends VerificationDomainApi {
     (data.reportSmsVerificationByIdentityRequestBody as any).method = 'sms';
     const getParams = this.client.extractQueryParams<ReportSmsVerificationByIdentityRequestData>(data, [] as never[]);
     const headers: { [key: string]: string | undefined } = {
-      'Content-Type': 'application/json; charset=UTF-8',
+      'Content-Type': 'application/json',
       'Accept': 'application/json',
     };
 
@@ -244,7 +244,7 @@ export class VerificationsApi extends VerificationDomainApi {
     const getParams = this.client.extractQueryParams<ReportFlashCallVerificationByIdentityRequestData>(
       data, [] as never[]);
     const headers: { [key: string]: string | undefined } = {
-      'Content-Type': 'application/json; charset=UTF-8',
+      'Content-Type': 'application/json',
       'Accept': 'application/json',
     };
 
@@ -279,7 +279,7 @@ export class VerificationsApi extends VerificationDomainApi {
     const getParams = this.client.extractQueryParams<ReportPhoneCallVerificationByIdentityRequestData>(
       data, [] as never[]);
     const headers: { [key: string]: string | undefined } = {
-      'Content-Type': 'application/json; charset=UTF-8',
+      'Content-Type': 'application/json',
       'Accept': 'application/json',
     };
 
@@ -318,7 +318,7 @@ export class VerificationsApi extends VerificationDomainApi {
    * Report a Callout verification using Identity
    * Report the received verification code (OTP) to verify it, using the identity of the user (in most cases, the phone number).
    * @param { ReportCalloutVerificationByIdentityRequestData } data - The data to provide to the API call.
-   * @deprecated
+   * @deprecated Use the method reportPhoneCallByIdentity() instead
    */
   public async reportCalloutByIdentity(
     data: ReportCalloutVerificationByIdentityRequestData,
@@ -328,7 +328,7 @@ export class VerificationsApi extends VerificationDomainApi {
     const getParams = this.client.extractQueryParams<ReportCalloutVerificationByIdentityRequestData>(
       data, [] as never[]);
     const headers: { [key: string]: string | undefined } = {
-      'Content-Type': 'application/json; charset=UTF-8',
+      'Content-Type': 'application/json',
       'Accept': 'application/json',
     };
 
@@ -533,14 +533,14 @@ export class VerificationsApi extends VerificationDomainApi {
    * Start verification with a callout
    * This method is used by the mobile and web Verification SDKs to start a verification. It can also be used to request a verification from your backend, by making a request.
    * @param { StartCalloutVerificationRequestData } data - The data to provide to the API call.
-   * @deprecated
+   * @deprecated Use the method startPhoneCall() instead
    */
   public async startCallout(data: StartCalloutVerificationRequestData): Promise<StartCalloutVerificationResponse> {
     this.client = this.getSinchClient();
     (data.startVerificationWithCalloutRequestBody as any).method = 'callout';
     const getParams = this.client.extractQueryParams<StartCalloutVerificationRequestData>(data, [] as never[]);
     const headers: { [key: string]: string | undefined } = {
-      'Content-Type': 'application/json; charset=UTF-8',
+      'Content-Type': 'application/json',
       'Accept': 'application/json',
     };
 
@@ -566,14 +566,14 @@ export class VerificationsApi extends VerificationDomainApi {
    * Start seamless verification (= data verification)
    * This method is used by the mobile and web Verification SDKs to start a verification. It can also be used to request a verification from your backend, by making a request.
    * @param { StartSeamlessVerificationRequestData } data - The data to provide to the API call.
-   * @deprecated
+   * @deprecated Use the method startData() instead
    */
   public async startSeamless(data: StartSeamlessVerificationRequestData): Promise<StartSeamlessVerificationResponse> {
     this.client = this.getSinchClient();
     (data.startSeamlessVerificationRequestBody as any).method = 'seamless';
     const getParams = this.client.extractQueryParams<StartSeamlessVerificationRequestData>(data, [] as never[]);
     const headers: { [key: string]: string | undefined } = {
-      'Content-Type': 'application/json; charset=UTF-8',
+      'Content-Type': 'application/json',
       'Accept': 'application/json',
     };
 

--- a/packages/voice/CHANGELOG.md
+++ b/packages/voice/CHANGELOG.md
@@ -1,3 +1,21 @@
+## Version 1.2.0
+- [Tech] Update dependency `@sinch/sdk-client` to `1.2.0`.
+- [Feature] In the interface `Participant`, the property `type` defines a list of string values on top of a generic string.
+- [Breaking TS] In the interface `ConferenceCalloutRequest`, the property `mohClass` was declared as a `string` and is now a `MusicOnHold` type;
+- [Deprecation Notice] The type `VoiceCallback` becomes `VoiceCallbackEvent` and is accessible on the `Voice` namespace.
+```typescript
+// Deprecated
+handleEvent(event: VoiceCallback, res: Response) {
+  console.log(event);
+}
+
+// New
+handleEvent(event: Voice.VoiceCallbackEvent, res: Response) {
+  console.log(event);
+}
+```
+- [E2E] Add Cucumber steps implementation.
+
 ## Version 1.1.0
 - [Tech] Update dependency `@sinch/sdk-client` to `1.1.0`
 

--- a/packages/voice/CHANGELOG.md
+++ b/packages/voice/CHANGELOG.md
@@ -1,19 +1,13 @@
 ## Version 1.2.0
 - [Tech] Update dependency `@sinch/sdk-client` to `1.2.0`.
 - [Feature] In the interface `Participant`, the property `type` defines a list of string values on top of a generic string.
-- [Breaking TS] In the interface `ConferenceCalloutRequest`, the property `mohClass` was declared as a `string` and is now a `MusicOnHold` type;
+- [Breaking] In the interface `ConferenceCalloutRequest`, the property `mohClass` was declared as a `string` and is now a `MusicOnHold` type;
 - [Deprecation Notice] The type `VoiceCallback` becomes `VoiceCallbackEvent` and is accessible on the `Voice` namespace.
-```typescript
-// Deprecated
-handleEvent(event: VoiceCallback, res: Response) {
-  console.log(event);
-}
 
-// New
-handleEvent(event: Voice.VoiceCallbackEvent, res: Response) {
-  console.log(event);
-}
-```
+| Deprecated                                                                                                           | New                                                                                                                             |
+|----------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| <pre><code>handleEvent(event: VoiceCallback, res: Response) {<br/>&nbsp;&nbsp;console.log(event);<br/>}</code></pre> | <pre><code>handleEvent(event: Voice.VoiceCallbackEvent, res: Response) {<br/>&nbsp;&nbsp;console.log(event);<br/>}</code></pre> |
+
 - [E2E] Add Cucumber steps implementation.
 
 ## Version 1.1.0

--- a/packages/voice/src/rest/v1/callbacks/callbacks-webhook.ts
+++ b/packages/voice/src/rest/v1/callbacks/callbacks-webhook.ts
@@ -2,7 +2,7 @@ import { AceRequest, DiceRequest, IceRequest, NotifyRequest, PieRequest, VoiceCa
 import { CallbackProcessor, SinchClientParameters, validateAuthenticationHeader } from '@sinch/sdk-client';
 import { IncomingHttpHeaders } from 'http';
 
-/** @deprecated - use Voice.VoiceCallbackEvent instead */
+/** @deprecated Use Voice.VoiceCallbackEvent instead */
 export type VoiceCallback = IceRequest | AceRequest | DiceRequest | PieRequest | NotifyRequest;
 
 export class VoiceCallbackWebhooks implements CallbackProcessor<VoiceCallbackEvent>{


### PR DESCRIPTION
- Report all the breaking changes in interfaces and methods in change logs
- Revert previously deleted interfaces and mark them as deprecated. They will be deleted in v2.0