### PR TITLE
DEVEXP-590: Improve CI performance

### DIFF
--- a/.github/workflows/run-ci.yaml
+++ b/.github/workflows/run-ci.yaml
@@ -1,6 +1,6 @@
 name: Build and test Sinch Node.js SDK
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -10,19 +10,45 @@ jobs:
         node-version: [18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Set up Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: yarn install
-      - run: npx eslint "packages/**/src/**/*.ts"
-      - run: npx eslint "packages/**/tests/**/*.ts"
-      - run: yarn run build
-      - run: yarn run test
+
+      - name: Cache Node.js modules
+        uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run ESLint
+        run: npx eslint "packages/**/{src,tests}/**/*.ts"
+
+      - name: Build project
+        run: yarn run build
+
+      - name: Cache build output
+        uses: actions/cache@v3
+        with:
+          path: './build'
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-build-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-build-
+
+      - name: Run unit tests
+        run: yarn run test
 
   e2e:
     needs: build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ 18.x, 20.x ]
     steps:
       - uses: actions/checkout@v3
       - name: Checkout sinch-sdk-mockserver repository
@@ -32,14 +58,38 @@ jobs:
           token: ${{ secrets.PAT_CI }}
           fetch-depth: 0
           path: sinch-sdk-mockserver
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Restore Node.js modules cache
+        uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-
+
+      - name: Restore build output
+        uses: actions/cache@v3
+        with:
+          path: './build'
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-build-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-build-
+
       - name: Install Docker Compose
         run: |
           sudo apt-get update
           sudo apt-get install -y docker-compose
+
       - name: Start mock servers with Docker Compose
         run: |
           cd sinch-sdk-mockserver
           docker-compose up -d
+
       - name: Create target directories for feature files
         run: |
           mkdir -p ./packages/fax/tests/e2e/features
@@ -49,6 +99,7 @@ jobs:
           mkdir -p ./packages/sms/tests/e2e/features
           mkdir -p ./packages/verification/tests/e2e/features
           mkdir -p ./packages/voice/tests/e2e/features
+
       - name: Copy feature files
         run: |
           cp sinch-sdk-mockserver/features/fax/*.feature ./packages/fax/tests/e2e/features/
@@ -58,11 +109,9 @@ jobs:
           cp sinch-sdk-mockserver/features/sms/*.feature ./packages/sms/tests/e2e/features/
           cp sinch-sdk-mockserver/features/verification/*.feature ./packages/verification/tests/e2e/features/
           cp sinch-sdk-mockserver/features/voice/*.feature ./packages/voice/tests/e2e/features/
+
       - name: Run e2e tests
-        run: |
-          yarn install
-          yarn run build
-          yarn run e2e
+        run: yarn run e2e
 
   sonarcloud:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-ci.yaml
+++ b/.github/workflows/run-ci.yaml
@@ -18,7 +18,9 @@ jobs:
       - name: Cache Node.js modules
         uses: actions/cache@v3
         with:
-          path: '**/node_modules'
+          path: |
+            node_modules
+            packages/**/node_modules
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node-${{ matrix.node-version }}-
@@ -35,7 +37,8 @@ jobs:
       - name: Cache build output
         uses: actions/cache@v3
         with:
-          path: './build'
+          path: |
+            packages/**/dist
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-build-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-node-${{ matrix.node-version }}-build-
@@ -67,7 +70,9 @@ jobs:
       - name: Restore Node.js modules cache
         uses: actions/cache@v3
         with:
-          path: '**/node_modules'
+          path: |
+            node_modules
+            packages/**/node_modules
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node-${{ matrix.node-version }}-
@@ -75,7 +80,8 @@ jobs:
       - name: Restore build output
         uses: actions/cache@v3
         with:
-          path: './build'
+          path: |
+            packages/**/dist
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-build-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-node-${{ matrix.node-version }}-build-

--- a/.github/workflows/run-ci.yaml
+++ b/.github/workflows/run-ci.yaml
@@ -16,7 +16,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install
 
       - name: Run ESLint
         run: npx eslint "packages/**/{src,tests}/**/*.ts"
@@ -24,26 +24,9 @@ jobs:
       - name: Build project
         run: yarn run build
 
-      - name: Cache build output
-        uses: actions/cache@v3
-        with:
-          path: |
-            packages/**/dist
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-build-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-build-
-
       - name: Run unit tests
         run: yarn run test
 
-  e2e:
-    needs: build
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [ 18.x, 20.x ]
-    steps:
-      - uses: actions/checkout@v3
       - name: Checkout sinch-sdk-mockserver repository
         uses: actions/checkout@v3
         with:
@@ -51,20 +34,6 @@ jobs:
           token: ${{ secrets.PAT_CI }}
           fetch-depth: 0
           path: sinch-sdk-mockserver
-
-      - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Restore build output
-        uses: actions/cache@v3
-        with:
-          path: |
-            packages/**/dist
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-build-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-build-
 
       - name: Install Docker Compose
         run: |
@@ -97,9 +66,7 @@ jobs:
           cp sinch-sdk-mockserver/features/voice/*.feature ./packages/voice/tests/e2e/features/
 
       - name: Run e2e tests
-        run: |
-          yarn install
-          yarn run e2e
+        run: yarn run e2e
 
   sonarcloud:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-ci.yaml
+++ b/.github/workflows/run-ci.yaml
@@ -15,16 +15,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Cache Node.js modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            node_modules
-            packages/**/node_modules
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-
-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
@@ -67,16 +57,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Restore Node.js modules cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            node_modules
-            packages/**/node_modules
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-
-
       - name: Restore build output
         uses: actions/cache@v3
         with:
@@ -117,7 +97,9 @@ jobs:
           cp sinch-sdk-mockserver/features/voice/*.feature ./packages/voice/tests/e2e/features/
 
       - name: Run e2e tests
-        run: yarn run e2e
+        run: |
+          yarn install
+          yarn run e2e
 
   sonarcloud:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-ci.yaml
+++ b/.github/workflows/run-ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
The initial idea was to cache the installed Node.js modules and the build output to use them in another job, but caching the artifact takes way too much time to be useful.
So I put all the steps in a single job, reducing the total build time from 3'35" to 2'31"