### PR TITLE
Add missing content-type header when sending formdata

### DIFF
--- a/packages/fax/src/rest/v3/faxes/faxes-api.ts
+++ b/packages/fax/src/rest/v3/faxes/faxes-api.ts
@@ -219,6 +219,7 @@ export class FaxesApi extends FaxDomainApi {
       headers['Content-Type'] = 'application/json';
       body = JSON.stringify(data['sendFaxRequestBody']);
     } else {
+      headers['Content-Type'] = 'multipart/form-data';
       const formData = new FormData();
       let requestData;
       if (Array.isArray(data.sendFaxRequestBody.to)) {


### PR DESCRIPTION
While working with Mailgun API and their formdata request, I noticed the content-type header was missing for Fax