### PR TITLE
Bugfix: Add debug option to log response headers

### DIFF
--- a/examples/snippets/package.json
+++ b/examples/snippets/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "build": "tsc --noEmit",
+    "sdk-client:logger": "node sdk-client/logger.js",
     "conversation:app:create": "node conversation/applications/create.js",
     "conversation:app:get": "node conversation/applications/get.js",
     "conversation:app:list": "node conversation/applications/list.js",

--- a/examples/snippets/package.json
+++ b/examples/snippets/package.json
@@ -6,7 +6,8 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@sinch/sdk-core": "^1.4.3"
+    "@sinch/sdk-core": "^1.4.3",
+    "winston": "^3.17.0"
   },
   "scripts": {
     "build": "tsc --noEmit",

--- a/examples/snippets/sdk-client/logger.js
+++ b/examples/snippets/sdk-client/logger.js
@@ -1,11 +1,13 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
 /**
  * Sinch Node.js Snippet
  * See: https://github.com/sinch/sinch-sdk-node/examples/snippets
  *
  * The SDK accepts any object implementing the Logger interface (debug, info, warn, error).
- * Pass it via the `logger` option on SinchClient.
+ * Pass it via the `logger` option on SinchClient as it is wrapped in SinchLogger automatically.
  *
- * Example with Winston (install separately: npm install winston):
+ * Example with Winston (https://www.npmjs.com/package/winston or npm install winston):
  *
  *   import winston from 'winston';
  *
@@ -20,22 +22,30 @@
 import { SinchClient } from '@sinch/sdk-core';
 import * as dotenv from 'dotenv';
 
+
 dotenv.config();
+
+const appLogger = {
+  debug: (message, ...meta) => console.debug(message, ...meta),
+  info: (message, ...meta) => console.info(message, ...meta),
+  warn: (message, ...meta) => console.warn(message, ...meta),
+  error: (message, ...meta) => console.error(message, ...meta),
+};
 
 async function main() {
   const projectId = process.env.SINCH_PROJECT_ID ?? 'MY_PROJECT_ID';
   const keyId = process.env.SINCH_KEY_ID ?? 'MY_KEY_ID';
   const keySecret = process.env.SINCH_KEY_SECRET ?? 'MY_KEY_SECRET';
 
-  // Omit `logger` to use console, pass `logger: null` to silence SDK output,
-  // or pass a custom logger — see the Winston example in the header comment.
-  const sinch = new SinchClient({ projectId, keyId, keySecret });
+  // conversationRegion is intentionally omitted to trigger an SDK deprecation warning
+  // and show the custom logger in action
+  const sinch = new SinchClient({ projectId, keyId, keySecret, logger: appLogger });
 
   try {
-    await sinch.numbers.availableRegions.list();
+    await sinch.conversation.app.list({});
     console.log('✅ SDK request completed.');
   } catch (err) {
-    console.error('❌ Failed to call the Numbers API:');
+    console.error('❌ Failed to call the Conversation API:');
     console.error(err);
   }
 }

--- a/examples/snippets/sdk-client/logger.js
+++ b/examples/snippets/sdk-client/logger.js
@@ -1,0 +1,43 @@
+/**
+ * Sinch Node.js Snippet
+ * See: https://github.com/sinch/sinch-sdk-node/examples/snippets
+ *
+ * The SDK accepts any object implementing the Logger interface (debug, info, warn, error).
+ * Pass it via the `logger` option on SinchClient.
+ *
+ * Example with Winston (install separately: npm install winston):
+ *
+ *   import winston from 'winston';
+ *
+ *   const winstonLogger = winston.createLogger({
+ *     level: 'debug',
+ *     transports: [new winston.transports.Console()],
+ *     format: winston.format.logstash(),
+ *   });
+ *
+ *   new SinchClient({ projectId, keyId, keySecret, logger: winstonLogger });
+ */
+import { SinchClient } from '@sinch/sdk-core';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+async function main() {
+  const projectId = process.env.SINCH_PROJECT_ID ?? 'MY_PROJECT_ID';
+  const keyId = process.env.SINCH_KEY_ID ?? 'MY_KEY_ID';
+  const keySecret = process.env.SINCH_KEY_SECRET ?? 'MY_KEY_SECRET';
+
+  // Omit `logger` to use console, pass `logger: null` to silence SDK output,
+  // or pass a custom logger — see the Winston example in the header comment.
+  const sinch = new SinchClient({ projectId, keyId, keySecret });
+
+  try {
+    await sinch.numbers.availableRegions.list();
+    console.log('✅ SDK request completed.');
+  } catch (err) {
+    console.error('❌ Failed to call the Numbers API:');
+    console.error(err);
+  }
+}
+
+main();

--- a/examples/snippets/sdk-client/logger.js
+++ b/examples/snippets/sdk-client/logger.js
@@ -1,52 +1,43 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
 /**
  * Sinch Node.js Snippet
  * See: https://github.com/sinch/sinch-sdk-node/examples/snippets
  *
  * The SDK accepts any object implementing the Logger interface (debug, info, warn, error).
- * Pass it via the `logger` option on SinchClient as it is wrapped in SinchLogger automatically.
+ * Pass it via the `logger` option — it is wrapped in SinchLogger automatically.
  *
- * Example with Winston (https://www.npmjs.com/package/winston or npm install winston):
- *
- *   import winston from 'winston';
- *
- *   const winstonLogger = winston.createLogger({
- *     level: 'debug',
- *     transports: [new winston.transports.Console()],
- *     format: winston.format.logstash(),
- *   });
- *
- *   new SinchClient({ projectId, keyId, keySecret, logger: winstonLogger });
+ * This example uses Winston (https://www.npmjs.com/package/winston). An invalid OAuth
+ * endpoint is used on purpose so the token request fails with an HTTP error and the SDK
+ * logs the response details at debug level.
  */
-import { SinchClient } from '@sinch/sdk-core';
-import * as dotenv from 'dotenv';
+import { Oauth2TokenRequest } from '@sinch/sdk-core';
+import { Headers } from 'node-fetch';
+import * as winston from 'winston';
 
-
-dotenv.config();
-
-const appLogger = {
-  debug: (message, ...meta) => console.debug(message, ...meta),
-  info: (message, ...meta) => console.info(message, ...meta),
-  warn: (message, ...meta) => console.warn(message, ...meta),
-  error: (message, ...meta) => console.error(message, ...meta),
-};
+const winstonLogger = winston.createLogger({
+  level: 'debug',
+  transports: [new winston.transports.Console()],
+  format: winston.format.printf(({ level, message }) => {
+    const text = typeof message === 'function' ? message() : message;
+    return JSON.stringify({ '@fields': { level }, '@message': text });
+  }),
+});
 
 async function main() {
-  const projectId = process.env.SINCH_PROJECT_ID ?? 'MY_PROJECT_ID';
-  const keyId = process.env.SINCH_KEY_ID ?? 'MY_KEY_ID';
-  const keySecret = process.env.SINCH_KEY_SECRET ?? 'MY_KEY_SECRET';
+  const keyId = 'MY_KEY_ID';
+  const keySecret = 'MY_KEY_SECRET';
+  const invalidAuthHostname = 'https://example.com';
 
-  // conversationRegion is intentionally omitted to trigger an SDK deprecation warning
-  // and show the custom logger in action
-  const sinch = new SinchClient({ projectId, keyId, keySecret, logger: appLogger });
+  const oauthPlugin = new Oauth2TokenRequest(keyId, keySecret, invalidAuthHostname, winstonLogger);
 
   try {
-    await sinch.conversation.app.list({});
-    console.log('✅ SDK request completed.');
-  } catch (err) {
-    console.error('❌ Failed to call the Conversation API:');
-    console.error(err);
+    await oauthPlugin.load().transform({
+      method: 'GET',
+      headers: new Headers(),
+      hostname: '',
+    });
+    console.log('✅ OAuth token obtained.');
+  } catch {
+    console.log('✅ Expected OAuth failure. Check Winston debug output above.');
   }
 }
 

--- a/packages/conversation/src/rest/v1/conversation-domain-api.ts
+++ b/packages/conversation/src/rest/v1/conversation-domain-api.ts
@@ -4,6 +4,7 @@ import {
   ConversationRegion,
   SinchLogger,
   UnifiedCredentials,
+  resolveLogger,
 } from '@sinch/sdk-client';
 import { LazyConversationApiClient, LazyConversationTemplateApiClient } from './conversation-service';
 
@@ -66,7 +67,7 @@ export class ConversationDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
         'Impossible to assign the new credentials to the Conversation API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/conversation/src/rest/v1/conversation-domain-api.ts
+++ b/packages/conversation/src/rest/v1/conversation-domain-api.ts
@@ -65,7 +65,7 @@ export class ConversationDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      this.lazyClient.sharedConfig.logger!.error(
+      this.lazyClient.sharedConfig.logger.error(
         'Impossible to assign the new credentials to the Conversation API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/conversation/src/rest/v1/conversation-domain-api.ts
+++ b/packages/conversation/src/rest/v1/conversation-domain-api.ts
@@ -2,6 +2,7 @@ import {
   Api,
   ApiClient,
   ConversationRegion,
+  SinchLogger,
   UnifiedCredentials,
 } from '@sinch/sdk-client';
 import { LazyConversationApiClient, LazyConversationTemplateApiClient } from './conversation-service';
@@ -65,7 +66,9 @@ export class ConversationDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      console.error('Impossible to assign the new credentials to the Conversation API');
+      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+        'Impossible to assign the new credentials to the Conversation API',
+      );
       this.lazyClient.sharedConfig = parametersBackup;
       throw error;
     }

--- a/packages/conversation/src/rest/v1/conversation-domain-api.ts
+++ b/packages/conversation/src/rest/v1/conversation-domain-api.ts
@@ -2,9 +2,7 @@ import {
   Api,
   ApiClient,
   ConversationRegion,
-  SinchLogger,
   UnifiedCredentials,
-  resolveLogger,
 } from '@sinch/sdk-client';
 import { LazyConversationApiClient, LazyConversationTemplateApiClient } from './conversation-service';
 
@@ -67,7 +65,7 @@ export class ConversationDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
+      this.lazyClient.sharedConfig.logger!.error(
         'Impossible to assign the new credentials to the Conversation API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/conversation/src/rest/v1/conversation-service.ts
+++ b/packages/conversation/src/rest/v1/conversation-service.ts
@@ -6,6 +6,7 @@ import {
   ConversationRegion,
   formatRegionalizedHostname,
   SinchClientParameters,
+  SinchLogger,
   SupportedConversationRegion, UnifiedCredentials,
 } from '@sinch/sdk-client';
 import { ContactApi } from './contact';
@@ -35,7 +36,9 @@ export class LazyConversationApiClient {
         console.warn(DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
       }
       if(!Object.values(SupportedConversationRegion).includes(region as SupportedConversationRegion)) {
-        console.warn(`The region "${region}" is not known as a supported region for the Conversation API`);
+        new SinchLogger(this.sharedConfig.logger ?? console).warn(
+          `The region "${region}" is not known as a supported region for the Conversation API`,
+        );
       }
       const apiClientOptions = buildOAuth2ApiClientOptions(this.sharedConfig, 'Conversation');
       this.apiFetchClient = new ApiFetchClient(apiClientOptions);
@@ -68,7 +71,9 @@ export class LazyConversationTemplateApiClient {
         console.warn(DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
       }
       if(!Object.values(SupportedConversationRegion).includes(region as SupportedConversationRegion)) {
-        console.warn(`The region "${region}" is not known as a supported region for the Conversation API`);
+        new SinchLogger(this.sharedConfig.logger ?? console).warn(
+          `The region "${region}" is not known as a supported region for the Conversation API`,
+        );
       }
       const apiClientOptions = buildOAuth2ApiClientOptions(this.sharedConfig, 'Conversation');
       this.apiFetchClient = new ApiFetchClient(apiClientOptions);
@@ -198,7 +203,9 @@ export class ConversationService {
       this.lazyConversationClient.getApiClient();
       this.lazyConversationTemplateClient.getApiClient();
     } catch (error) {
-      console.error('Impossible to assign the new credentials to the Conversation API');
+      new SinchLogger(this.lazyConversationClient.sharedConfig.logger ?? console).error(
+        'Impossible to assign the new credentials to the Conversation API',
+      );
       this.lazyConversationClient.sharedConfig = parametersBackup;
       this.lazyConversationTemplateClient.sharedConfig = parametersTemplatesBackup;
       throw error;

--- a/packages/conversation/src/rest/v1/conversation-service.ts
+++ b/packages/conversation/src/rest/v1/conversation-service.ts
@@ -7,7 +7,8 @@ import {
   formatRegionalizedHostname,
   SinchClientParameters,
   SupportedConversationRegion, UnifiedCredentials,
-  resolveLogger,
+  LazyApiClient,
+  resolveClientParameters,
 } from '@sinch/sdk-client';
 import { ContactApi } from './contact';
 import { AppApi } from './app';
@@ -23,20 +24,17 @@ import { TemplatesV2Api } from './templates-v2';
 import { ConsentsApi } from './consents';
 import { DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING } from './conversation-domain-api';
 
-export class LazyConversationApiClient {
-  apiFetchClient?: ApiFetchClient;
-  constructor(public sharedConfig: SinchClientParameters) {}
-
+export class LazyConversationApiClient extends LazyApiClient {
   public getApiClient(): ApiFetchClient {
     if (!this.apiFetchClient) {
       const region = this.sharedConfig.conversationRegion ?? ConversationRegion.UNITED_STATES;
       // Deprecation Notice - to remove in 2.0
       const isConversationHostnameOverridden = !!this.sharedConfig.conversationHostname;
       if (!this.sharedConfig.conversationRegion && !isConversationHostnameOverridden) {
-      this.sharedConfig.logger!.warn(DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
+        this.sharedConfig.logger.warn(DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
       }
       if(!Object.values(SupportedConversationRegion).includes(region as SupportedConversationRegion)) {
-        this.sharedConfig.logger!.warn(
+        this.sharedConfig.logger.warn(
           `The region "${region}" is not known as a supported region for the Conversation API`,
         );
       }
@@ -45,10 +43,6 @@ export class LazyConversationApiClient {
       this.apiFetchClient.apiClientOptions.hostname = this.buildHostname(region);
     }
     return this.apiFetchClient;
-  }
-
-  public resetApiClient() {
-    this.apiFetchClient = undefined;
   }
 
   private buildHostname(region: ConversationRegion) {
@@ -58,20 +52,17 @@ export class LazyConversationApiClient {
   }
 }
 
-export class LazyConversationTemplateApiClient {
-  apiFetchClient?: ApiFetchClient;
-  constructor(public sharedConfig: SinchClientParameters) {}
-
+export class LazyConversationTemplateApiClient extends LazyApiClient {
   public getApiClient(): ApiFetchClient {
     if (!this.apiFetchClient) {
       const region = this.sharedConfig.conversationRegion ?? ConversationRegion.UNITED_STATES;
       // Deprecation Notice - to remove in 2.0
       const isConversationTemplatesHostnameOverridden = !!this.sharedConfig.conversationTemplatesHostname;
       if (!this.sharedConfig.conversationRegion && !isConversationTemplatesHostnameOverridden) {
-      this.sharedConfig.logger!.warn(DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
+        this.sharedConfig.logger.warn(DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
       }
       if(!Object.values(SupportedConversationRegion).includes(region as SupportedConversationRegion)) {
-        this.sharedConfig.logger!.warn(
+        this.sharedConfig.logger.warn(
           `The region "${region}" is not known as a supported region for the Conversation API`,
         );
       }
@@ -80,10 +71,6 @@ export class LazyConversationTemplateApiClient {
       this.apiFetchClient.apiClientOptions.hostname = this.buildHostname(region);
     }
     return this.apiFetchClient;
-  }
-
-  public resetApiClient() {
-    this.apiFetchClient = undefined;
   }
 
   private buildHostname(region: ConversationRegion) {
@@ -137,11 +124,11 @@ export class ConversationService {
    * @param {SinchClientParameters} params - an Object containing the necessary properties to initialize the service
    */
   constructor(params: SinchClientParameters) {
-    params.logger = resolveLogger(params.logger);
-    const sharedConversationClient = new LazyConversationApiClient(params);
+    const sharedConfig = resolveClientParameters(params);
+    const sharedConversationClient = new LazyConversationApiClient(sharedConfig);
     this.lazyConversationClient = sharedConversationClient;
 
-    const sharedConversationTemplateClient = new LazyConversationTemplateApiClient(params);
+    const sharedConversationTemplateClient = new LazyConversationTemplateApiClient(sharedConfig);
     this.lazyConversationTemplateClient = sharedConversationTemplateClient;
 
     this.contact = new ContactApi(sharedConversationClient);
@@ -159,9 +146,10 @@ export class ConversationService {
   }
 
   public setApiClientConfig(newParams: SinchClientParameters) {
-    this.lazyConversationClient.sharedConfig = newParams;
+    const resolvedParams = resolveClientParameters(newParams);
+    this.lazyConversationClient.sharedConfig = resolvedParams;
     this.lazyConversationClient.resetApiClient();
-    this.lazyConversationTemplateClient.sharedConfig = newParams;
+    this.lazyConversationTemplateClient.sharedConfig = resolvedParams;
     this.lazyConversationTemplateClient.resetApiClient();
   }
 
@@ -204,7 +192,7 @@ export class ConversationService {
       this.lazyConversationClient.getApiClient();
       this.lazyConversationTemplateClient.getApiClient();
     } catch (error) {
-      this.lazyConversationClient.sharedConfig.logger!.error(
+      this.lazyConversationClient.sharedConfig.logger.error(
         'Impossible to assign the new credentials to the Conversation API',
       );
       this.lazyConversationClient.sharedConfig = parametersBackup;

--- a/packages/conversation/src/rest/v1/conversation-service.ts
+++ b/packages/conversation/src/rest/v1/conversation-service.ts
@@ -124,11 +124,11 @@ export class ConversationService {
    * @param {SinchClientParameters} params - an Object containing the necessary properties to initialize the service
    */
   constructor(params: SinchClientParameters) {
-    const sharedConfig = resolveClientParameters(params);
-    const sharedConversationClient = new LazyConversationApiClient(sharedConfig);
+    const resolvedParams = resolveClientParameters(params);
+    const sharedConversationClient = new LazyConversationApiClient(resolvedParams);
     this.lazyConversationClient = sharedConversationClient;
 
-    const sharedConversationTemplateClient = new LazyConversationTemplateApiClient(sharedConfig);
+    const sharedConversationTemplateClient = new LazyConversationTemplateApiClient(resolvedParams);
     this.lazyConversationTemplateClient = sharedConversationTemplateClient;
 
     this.contact = new ContactApi(sharedConversationClient);

--- a/packages/conversation/src/rest/v1/conversation-service.ts
+++ b/packages/conversation/src/rest/v1/conversation-service.ts
@@ -8,6 +8,7 @@ import {
   SinchClientParameters,
   SinchLogger,
   SupportedConversationRegion, UnifiedCredentials,
+  resolveLogger,
 } from '@sinch/sdk-client';
 import { ContactApi } from './contact';
 import { AppApi } from './app';
@@ -33,10 +34,10 @@ export class LazyConversationApiClient {
       // Deprecation Notice - to remove in 2.0
       const isConversationHostnameOverridden = !!this.sharedConfig.conversationHostname;
       if (!this.sharedConfig.conversationRegion && !isConversationHostnameOverridden) {
-        console.warn(DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
+        new SinchLogger(resolveLogger(this.sharedConfig.logger)).warn(DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
       }
       if(!Object.values(SupportedConversationRegion).includes(region as SupportedConversationRegion)) {
-        new SinchLogger(this.sharedConfig.logger ?? console).warn(
+        new SinchLogger(resolveLogger(this.sharedConfig.logger)).warn(
           `The region "${region}" is not known as a supported region for the Conversation API`,
         );
       }
@@ -68,10 +69,10 @@ export class LazyConversationTemplateApiClient {
       // Deprecation Notice - to remove in 2.0
       const isConversationTemplatesHostnameOverridden = !!this.sharedConfig.conversationTemplatesHostname;
       if (!this.sharedConfig.conversationRegion && !isConversationTemplatesHostnameOverridden) {
-        console.warn(DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
+        new SinchLogger(resolveLogger(this.sharedConfig.logger)).warn(DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
       }
       if(!Object.values(SupportedConversationRegion).includes(region as SupportedConversationRegion)) {
-        new SinchLogger(this.sharedConfig.logger ?? console).warn(
+        new SinchLogger(resolveLogger(this.sharedConfig.logger)).warn(
           `The region "${region}" is not known as a supported region for the Conversation API`,
         );
       }
@@ -137,6 +138,7 @@ export class ConversationService {
    * @param {SinchClientParameters} params - an Object containing the necessary properties to initialize the service
    */
   constructor(params: SinchClientParameters) {
+    params.logger = resolveLogger(params.logger);
     const sharedConversationClient = new LazyConversationApiClient(params);
     this.lazyConversationClient = sharedConversationClient;
 
@@ -203,7 +205,7 @@ export class ConversationService {
       this.lazyConversationClient.getApiClient();
       this.lazyConversationTemplateClient.getApiClient();
     } catch (error) {
-      new SinchLogger(this.lazyConversationClient.sharedConfig.logger ?? console).error(
+      new SinchLogger(resolveLogger(this.lazyConversationClient.sharedConfig.logger)).error(
         'Impossible to assign the new credentials to the Conversation API',
       );
       this.lazyConversationClient.sharedConfig = parametersBackup;

--- a/packages/conversation/src/rest/v1/conversation-service.ts
+++ b/packages/conversation/src/rest/v1/conversation-service.ts
@@ -6,7 +6,6 @@ import {
   ConversationRegion,
   formatRegionalizedHostname,
   SinchClientParameters,
-  SinchLogger,
   SupportedConversationRegion, UnifiedCredentials,
   resolveLogger,
 } from '@sinch/sdk-client';
@@ -34,10 +33,10 @@ export class LazyConversationApiClient {
       // Deprecation Notice - to remove in 2.0
       const isConversationHostnameOverridden = !!this.sharedConfig.conversationHostname;
       if (!this.sharedConfig.conversationRegion && !isConversationHostnameOverridden) {
-        new SinchLogger(resolveLogger(this.sharedConfig.logger)).warn(DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
+      this.sharedConfig.logger!.warn(DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
       }
       if(!Object.values(SupportedConversationRegion).includes(region as SupportedConversationRegion)) {
-        new SinchLogger(resolveLogger(this.sharedConfig.logger)).warn(
+        this.sharedConfig.logger!.warn(
           `The region "${region}" is not known as a supported region for the Conversation API`,
         );
       }
@@ -69,10 +68,10 @@ export class LazyConversationTemplateApiClient {
       // Deprecation Notice - to remove in 2.0
       const isConversationTemplatesHostnameOverridden = !!this.sharedConfig.conversationTemplatesHostname;
       if (!this.sharedConfig.conversationRegion && !isConversationTemplatesHostnameOverridden) {
-        new SinchLogger(resolveLogger(this.sharedConfig.logger)).warn(DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
+      this.sharedConfig.logger!.warn(DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
       }
       if(!Object.values(SupportedConversationRegion).includes(region as SupportedConversationRegion)) {
-        new SinchLogger(resolveLogger(this.sharedConfig.logger)).warn(
+        this.sharedConfig.logger!.warn(
           `The region "${region}" is not known as a supported region for the Conversation API`,
         );
       }
@@ -205,7 +204,7 @@ export class ConversationService {
       this.lazyConversationClient.getApiClient();
       this.lazyConversationTemplateClient.getApiClient();
     } catch (error) {
-      new SinchLogger(resolveLogger(this.lazyConversationClient.sharedConfig.logger)).error(
+      this.lazyConversationClient.sharedConfig.logger!.error(
         'Impossible to assign the new credentials to the Conversation API',
       );
       this.lazyConversationClient.sharedConfig = parametersBackup;

--- a/packages/conversation/tests/rest/v1/app/app-api.test.ts
+++ b/packages/conversation/tests/rest/v1/app/app-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters } from '@sinch/sdk-client';
 import {
   AppApi,
   AppApiFixture,
@@ -19,7 +19,7 @@ describe('AppApi', () => {
       keySecret: 'KEY_SECRET',
     };
 
-    const lazyClient = new LazyConversationApiClient(credentials);
+    const lazyClient = new LazyConversationApiClient(resolveClientParameters(credentials));
     appApi = new AppApi(lazyClient);
   });
 

--- a/packages/conversation/tests/rest/v1/capability/capability-api.test.ts
+++ b/packages/conversation/tests/rest/v1/capability/capability-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters } from '@sinch/sdk-client';
 import {
   CapabilityApi,
   CapabilityApiFixture,
@@ -19,7 +19,7 @@ describe('CapabilityApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyConversationApiClient(credentials);
+    const lazyClient = new LazyConversationApiClient(resolveClientParameters(credentials));
     capabilityApi = new CapabilityApi(lazyClient);
   });
 

--- a/packages/conversation/tests/rest/v1/consents/consents-api.test.ts
+++ b/packages/conversation/tests/rest/v1/consents/consents-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import { ConsentsApi, ConsentsApiFixture, Conversation, LazyConversationApiClient } from '../../../../src';
 
 describe('ConsentsApi', () => {
@@ -13,7 +13,7 @@ describe('ConsentsApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyConversationApiClient(credentials);
+    const lazyClient = new LazyConversationApiClient(resolveClientParameters(credentials));
     consentsApi = new ConsentsApi(lazyClient);
   });
 

--- a/packages/conversation/tests/rest/v1/contact/contact-api.test.ts
+++ b/packages/conversation/tests/rest/v1/contact/contact-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   ContactApi,
   ContactApiFixture,
@@ -19,7 +19,7 @@ describe('ContactApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyConversationApiClient(credentials);
+    const lazyClient = new LazyConversationApiClient(resolveClientParameters(credentials));
     contactApi = new ContactApi(lazyClient);
   });
 

--- a/packages/conversation/tests/rest/v1/conversation-domain-api.test.ts
+++ b/packages/conversation/tests/rest/v1/conversation-domain-api.test.ts
@@ -53,8 +53,8 @@ describe('Conversation API', () => {
     params.conversationRegion = 'bzh';
     conversationApi = new ConversationDomainApi(lazyClient, 'dummy');
     expect(conversationApi.client).toBeDefined();
-    expect(warnSpy).toHaveBeenCalledWith(
-      'The region "bzh" is not known as a supported region for the Conversation API');
+    expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] '
+      + 'The region "bzh" is not known as a supported region for the Conversation API');
     expect(conversationApi.client?.apiClientOptions.hostname).toBe('https://bzh.conversation.api.sinch.com');
   });
 
@@ -138,7 +138,8 @@ describe('Conversation API', () => {
     expect(() => conversationApi.setCredentials({ projectId: '' }))
       .toThrow('Invalid configuration for the Conversation API: "projectId", "keyId" and "keySecret"'
         + ' values must be provided');
-    expect(errorSpy).toHaveBeenCalledWith('Impossible to assign the new credentials to the Conversation API');
+    expect(errorSpy).toHaveBeenCalledWith('[Sinch SDK][Error] '
+      + 'Impossible to assign the new credentials to the Conversation API');
   });
 
 });

--- a/packages/conversation/tests/rest/v1/conversation-domain-api.test.ts
+++ b/packages/conversation/tests/rest/v1/conversation-domain-api.test.ts
@@ -38,7 +38,7 @@ describe('Conversation API', () => {
   it('should initialize the client with the default "us" region and log a warning', () => {
     conversationApi = new ConversationDomainApi(lazyClient, 'dummy');
     expect(conversationApi.client).toBeDefined();
-    expect(warnSpy).toHaveBeenCalledWith(DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
+    expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] ' + DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
     expect(conversationApi.client?.apiClientOptions.hostname).toBe('https://us.conversation.api.sinch.com');
   });
 
@@ -66,7 +66,7 @@ describe('Conversation API', () => {
     expect(warnSpy).toHaveBeenCalledTimes(0);
     warnSpy.mockClear();
     expect(templateApi.client?.apiClientOptions.hostname).toBe('https://us.template.api.sinch.com');
-    expect(warnSpy).toHaveBeenCalledWith(DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
+    expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] ' + DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
   });
 
   it('should use the hostname parameter for templates only', () => {
@@ -74,7 +74,7 @@ describe('Conversation API', () => {
     conversationApi = new ConversationDomainApi(lazyClient, 'dummy');
     templateApi = new ConversationDomainApi(lazyTemplateClient, 'dummy');
     expect(conversationApi.client?.apiClientOptions.hostname).toBe('https://us.conversation.api.sinch.com');
-    expect(warnSpy).toHaveBeenCalledWith(DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
+    expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] ' + DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
     warnSpy.mockClear();
     expect(templateApi.client?.apiClientOptions.hostname).toBe(CUSTOM_HOSTNAME_TEMPLATES);
     expect(warnSpy).toHaveBeenCalledTimes(0);
@@ -100,7 +100,7 @@ describe('Conversation API', () => {
   it ('should update the region', () => {
     conversationApi = new ConversationDomainApi(lazyClient, 'dummy');
     expect(conversationApi.client).toBeDefined();
-    expect(warnSpy).toHaveBeenCalledWith(DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
+    expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] ' + DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
     expect(conversationApi.client?.apiClientOptions.hostname).toBe('https://us.conversation.api.sinch.com');
     conversationApi.setRegion(ConversationRegion.UNITED_STATES);
     expect(conversationApi.client?.apiClientOptions.hostname).toBe('https://us.conversation.api.sinch.com');
@@ -117,7 +117,7 @@ describe('Conversation API', () => {
   it ('should update the region with an API using the template lazy client', () => {
     conversationApi = new ConversationDomainApi(lazyTemplateClient, 'dummy');
     expect(conversationApi.client).toBeDefined();
-    expect(warnSpy).toHaveBeenCalledWith(DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
+    expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] ' + DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
     expect(conversationApi.client?.apiClientOptions.hostname).toBe('https://us.template.api.sinch.com');
     conversationApi.setRegion(ConversationRegion.EUROPE);
     expect(conversationApi.client?.apiClientOptions.hostname).toBe('https://eu.template.api.sinch.com');

--- a/packages/conversation/tests/rest/v1/conversation-domain-api.test.ts
+++ b/packages/conversation/tests/rest/v1/conversation-domain-api.test.ts
@@ -4,7 +4,7 @@ import {
   LazyConversationApiClient,
   LazyConversationTemplateApiClient,
 } from '../../../src';
-import { ApiHostname, ConversationRegion, UnifiedCredentials } from '@sinch/sdk-client';
+import { ApiHostname, ConversationRegion, UnifiedCredentials, resolveClientParameters } from '@sinch/sdk-client';
 
 describe('Conversation API', () => {
   let conversationApi: ConversationDomainApi;
@@ -23,8 +23,8 @@ describe('Conversation API', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    lazyClient = new LazyConversationApiClient(params);
-    lazyTemplateClient = new LazyConversationTemplateApiClient(params);
+    lazyClient = new LazyConversationApiClient(resolveClientParameters(params));
+    lazyTemplateClient = new LazyConversationTemplateApiClient(resolveClientParameters(params));
     warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });

--- a/packages/conversation/tests/rest/v1/conversation-domain-api.test.ts
+++ b/packages/conversation/tests/rest/v1/conversation-domain-api.test.ts
@@ -43,14 +43,14 @@ describe('Conversation API', () => {
   });
 
   it('should change the URL when specifying a different region', () => {
-    params.conversationRegion = ConversationRegion.EUROPE;
+    lazyClient.sharedConfig.conversationRegion = ConversationRegion.EUROPE;
     conversationApi = new ConversationDomainApi(lazyClient, 'dummy');
     expect(conversationApi.client?.apiClientOptions.hostname).toBe('https://eu.conversation.api.sinch.com');
     expect(warnSpy).toHaveBeenCalledTimes(0);
   });
 
   it('should log a warning when using an unsupported region', async () => {
-    params.conversationRegion = 'bzh';
+    lazyClient.sharedConfig.conversationRegion = 'bzh';
     conversationApi = new ConversationDomainApi(lazyClient, 'dummy');
     expect(conversationApi.client).toBeDefined();
     expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] '
@@ -59,7 +59,7 @@ describe('Conversation API', () => {
   });
 
   it('should use the hostname parameter but not for templates', () => {
-    params.conversationHostname = CUSTOM_HOSTNAME;
+    lazyClient.sharedConfig.conversationHostname = CUSTOM_HOSTNAME;
     conversationApi = new ConversationDomainApi(lazyClient, 'dummy');
     templateApi = new ConversationDomainApi(lazyTemplateClient, 'dummy');
     expect(conversationApi.client?.apiClientOptions.hostname).toBe(CUSTOM_HOSTNAME);
@@ -70,7 +70,7 @@ describe('Conversation API', () => {
   });
 
   it('should use the hostname parameter for templates only', () => {
-    params.conversationTemplatesHostname = CUSTOM_HOSTNAME_TEMPLATES;
+    lazyTemplateClient.sharedConfig.conversationTemplatesHostname = CUSTOM_HOSTNAME_TEMPLATES;
     conversationApi = new ConversationDomainApi(lazyClient, 'dummy');
     templateApi = new ConversationDomainApi(lazyTemplateClient, 'dummy');
     expect(conversationApi.client?.apiClientOptions.hostname).toBe('https://us.conversation.api.sinch.com');
@@ -81,8 +81,8 @@ describe('Conversation API', () => {
   });
 
   it('should use the hostname parameter for the 2 different domains', () => {
-    params.conversationHostname = CUSTOM_HOSTNAME;
-    params.conversationTemplatesHostname = CUSTOM_HOSTNAME_TEMPLATES;
+    lazyClient.sharedConfig.conversationHostname = CUSTOM_HOSTNAME;
+    lazyTemplateClient.sharedConfig.conversationTemplatesHostname = CUSTOM_HOSTNAME_TEMPLATES;
     conversationApi = new ConversationDomainApi(lazyClient, 'dummy');
     templateApi = new ConversationDomainApi(lazyTemplateClient, 'dummy');
     expect(conversationApi.client?.apiClientOptions.hostname).toBe(CUSTOM_HOSTNAME);

--- a/packages/conversation/tests/rest/v1/conversation-service.test.ts
+++ b/packages/conversation/tests/rest/v1/conversation-service.test.ts
@@ -178,7 +178,7 @@ describe('Conversation Service', () => {
     expect(conversationService.templatesV1.client.apiClientOptions.hostname).toBe(DEFAULT_HOSTNAME_TEMPLATES);
     expect(conversationService.templatesV2.client.apiClientOptions.hostname).toBe(DEFAULT_HOSTNAME_TEMPLATES);
     expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy).toHaveBeenCalledWith(DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
+    expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] ' + DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
   });
 
   it('should set a custom hostnames for the templates APIs only', () => {
@@ -204,7 +204,7 @@ describe('Conversation Service', () => {
     expect(conversationService.webhooks.client.apiClientOptions.hostname).toBe(DEFAULT_HOSTNAME);
     expect(conversationService.consents.client.apiClientOptions.hostname).toBe(DEFAULT_HOSTNAME);
     expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy).toHaveBeenCalledWith(DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
+    expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] ' + DEFAULT_CONVERSATION_REGION_DEPRECATION_WARNING);
     warnSpy.mockClear();
     expect(conversationService.templatesV1.client.apiClientOptions.hostname).toBe(CUSTOM_HOSTNAME_TEMPLATES);
     expect(conversationService.templatesV2.client.apiClientOptions.hostname).toBe(CUSTOM_HOSTNAME_TEMPLATES);

--- a/packages/conversation/tests/rest/v1/conversation-service.test.ts
+++ b/packages/conversation/tests/rest/v1/conversation-service.test.ts
@@ -253,7 +253,8 @@ describe('Conversation Service', () => {
     expect(() => conversationService.setCredentials({ projectId: '' }))
       .toThrow('Invalid configuration for the Conversation API: "projectId", "keyId" and "keySecret"'
         + ' values must be provided');
-    expect(errorSpy).toHaveBeenCalledWith('Impossible to assign the new credentials to the Conversation API');
+    expect(errorSpy).toHaveBeenCalledWith('[Sinch SDK][Error] '
+      + 'Impossible to assign the new credentials to the Conversation API');
 
     // Then
     expect(conversationService.app.client.apiClientOptions.projectId).toBe('PROJECT_ID');

--- a/packages/conversation/tests/rest/v1/conversation/conversation-api.test.ts
+++ b/packages/conversation/tests/rest/v1/conversation/conversation-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   Conversation,
   ConversationApi,
@@ -18,7 +18,7 @@ describe('ConversationApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyConversationApiClient(credentials);
+    const lazyClient = new LazyConversationApiClient(resolveClientParameters(credentials));
     conversationApi = new ConversationApi(lazyClient);
   });
 

--- a/packages/conversation/tests/rest/v1/events/events-api.test.ts
+++ b/packages/conversation/tests/rest/v1/events/events-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   EventsApi,
   EventsApiFixture,
@@ -27,7 +27,7 @@ describe('EventsApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyConversationApiClient(credentials);
+    const lazyClient = new LazyConversationApiClient(resolveClientParameters(credentials));
     eventsApi = new EventsApi(lazyClient);
   });
 

--- a/packages/conversation/tests/rest/v1/messages/messages-api.test.ts
+++ b/packages/conversation/tests/rest/v1/messages/messages-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   MessagesApi,
   MessagesApiFixture,
@@ -30,7 +30,7 @@ describe('MessagesApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyConversationApiClient(credentials);
+    const lazyClient = new LazyConversationApiClient(resolveClientParameters(credentials));
     messagesApi = new MessagesApi(lazyClient);
   });
 

--- a/packages/conversation/tests/rest/v1/project-settings/project-settings-api.test.ts
+++ b/packages/conversation/tests/rest/v1/project-settings/project-settings-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   Conversation,
   LazyConversationApiClient,
@@ -18,7 +18,7 @@ describe('ProjectSettingsApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyConversationApiClient(credentials);
+    const lazyClient = new LazyConversationApiClient(resolveClientParameters(credentials));
     projectSettingsApi = new ProjectSettingsApi(lazyClient);
   });
 

--- a/packages/conversation/tests/rest/v1/templates-v1/templates-v1-api.test.ts
+++ b/packages/conversation/tests/rest/v1/templates-v1/templates-v1-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   TemplatesV1Api,
   TemplatesV1ApiFixture,
@@ -18,7 +18,7 @@ describe('TemplatesV1Api', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyConversationTemplateApiClient(credentials);
+    const lazyClient = new LazyConversationTemplateApiClient(resolveClientParameters(credentials));
     templatesV1Api = new TemplatesV1Api(lazyClient);
   });
 

--- a/packages/conversation/tests/rest/v1/templates-v2/templates-v2-api.test.ts
+++ b/packages/conversation/tests/rest/v1/templates-v2/templates-v2-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   TemplatesV2Api,
   TemplatesV2ApiFixture,
@@ -17,7 +17,7 @@ describe('TemplatesV2Api', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyConversationTemplateApiClient(credentials);
+    const lazyClient = new LazyConversationTemplateApiClient(resolveClientParameters(credentials));
     templatesV2Api = new TemplatesV2Api(lazyClient);
   });
 

--- a/packages/conversation/tests/rest/v1/transcoding/transcoding-api.test.ts
+++ b/packages/conversation/tests/rest/v1/transcoding/transcoding-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   TranscodingApi,
   TranscodingApiFixture,
@@ -18,7 +18,7 @@ describe('TranscodingApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyConversationApiClient(credentials);
+    const lazyClient = new LazyConversationApiClient(resolveClientParameters(credentials));
     transcodingApi = new TranscodingApi(lazyClient);
   });
 

--- a/packages/conversation/tests/rest/v1/webhooks/webhooks-api.test.ts
+++ b/packages/conversation/tests/rest/v1/webhooks/webhooks-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   WebhooksApi,
   WebhooksApiFixture,
@@ -18,7 +18,7 @@ describe('WebhooksApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyConversationApiClient(credentials);
+    const lazyClient = new LazyConversationApiClient(resolveClientParameters(credentials));
     webhooksApi = new WebhooksApi(lazyClient);
   });
 

--- a/packages/elastic-sip-trunking/src/rest/v1/elastic-sip-trunking-domain-api.ts
+++ b/packages/elastic-sip-trunking/src/rest/v1/elastic-sip-trunking-domain-api.ts
@@ -48,7 +48,7 @@ export class ElasticSipTrunkingDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      this.lazyClient.sharedConfig.logger!.error(
+      this.lazyClient.sharedConfig.logger.error(
         'Impossible to assign the new credentials to the Elastic SIP Trunking API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/elastic-sip-trunking/src/rest/v1/elastic-sip-trunking-domain-api.ts
+++ b/packages/elastic-sip-trunking/src/rest/v1/elastic-sip-trunking-domain-api.ts
@@ -1,9 +1,7 @@
 import {
   Api,
   ApiClient,
-  SinchLogger,
   UnifiedCredentials,
-  resolveLogger,
 } from '@sinch/sdk-client';
 import { LazyElasticSipTrunkingApiClient } from './elastic-sip-trunking-service';
 
@@ -50,7 +48,7 @@ export class ElasticSipTrunkingDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
+      this.lazyClient.sharedConfig.logger!.error(
         'Impossible to assign the new credentials to the Elastic SIP Trunking API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/elastic-sip-trunking/src/rest/v1/elastic-sip-trunking-domain-api.ts
+++ b/packages/elastic-sip-trunking/src/rest/v1/elastic-sip-trunking-domain-api.ts
@@ -1,6 +1,7 @@
 import {
   Api,
   ApiClient,
+  SinchLogger,
   UnifiedCredentials,
 } from '@sinch/sdk-client';
 import { LazyElasticSipTrunkingApiClient } from './elastic-sip-trunking-service';
@@ -48,7 +49,9 @@ export class ElasticSipTrunkingDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      console.error('Impossible to assign the new credentials to the Elastic SIP Trunking API');
+      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+        'Impossible to assign the new credentials to the Elastic SIP Trunking API',
+      );
       this.lazyClient.sharedConfig = parametersBackup;
       throw error;
     }

--- a/packages/elastic-sip-trunking/src/rest/v1/elastic-sip-trunking-domain-api.ts
+++ b/packages/elastic-sip-trunking/src/rest/v1/elastic-sip-trunking-domain-api.ts
@@ -3,6 +3,7 @@ import {
   ApiClient,
   SinchLogger,
   UnifiedCredentials,
+  resolveLogger,
 } from '@sinch/sdk-client';
 import { LazyElasticSipTrunkingApiClient } from './elastic-sip-trunking-service';
 
@@ -49,7 +50,7 @@ export class ElasticSipTrunkingDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
         'Impossible to assign the new credentials to the Elastic SIP Trunking API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/elastic-sip-trunking/src/rest/v1/elastic-sip-trunking-service.ts
+++ b/packages/elastic-sip-trunking/src/rest/v1/elastic-sip-trunking-service.ts
@@ -2,9 +2,9 @@ import {
   ApiFetchClient,
   buildOAuth2ApiClientOptions,
   ELASTIC_SIP_TRUNKING_HOSTNAME,
+  LazyApiClient,
   SinchClientParameters,
   UnifiedCredentials,
-  resolveLogger,
 } from '@sinch/sdk-client';
 import { SipTrunksApi } from './sip-trunks';
 import { AccessControlListApi } from './access-control-list';
@@ -16,10 +16,7 @@ import { CallBlockingRulesApi } from './call-blocking-rules';
 import { CredentialListsApi } from './credential-lists';
 import { PhoneNumbersApi } from './phone-numbers';
 
-export class LazyElasticSipTrunkingApiClient {
-  apiFetchClient?: ApiFetchClient;
-  constructor(public sharedConfig: SinchClientParameters) {}
-
+export class LazyElasticSipTrunkingApiClient extends LazyApiClient {
   public getApiClient(): ApiFetchClient {
     if (!this.apiFetchClient) {
       const apiClientOptions = buildOAuth2ApiClientOptions(this.sharedConfig, 'Elastic SIP Trunking');
@@ -28,10 +25,6 @@ export class LazyElasticSipTrunkingApiClient {
         ?? ELASTIC_SIP_TRUNKING_HOSTNAME;
     }
     return this.apiFetchClient;
-  }
-
-  public resetApiClient() {
-    this.apiFetchClient = undefined;
   }
 }
 
@@ -50,7 +43,6 @@ export class ElasticSipTrunkingService {
   public readonly lazyClient: LazyElasticSipTrunkingApiClient;
 
   constructor(params: SinchClientParameters) {
-    params.logger = resolveLogger(params.logger);
     this.lazyClient = new LazyElasticSipTrunkingApiClient(params);
 
     this.sipTrunks = new SipTrunksApi(this.lazyClient);
@@ -84,7 +76,7 @@ export class ElasticSipTrunkingService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      this.lazyClient.sharedConfig.logger!.error(
+      this.lazyClient.sharedConfig.logger.error(
         'Impossible to assign the new credentials to the Elastic SIP Trunking API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/elastic-sip-trunking/src/rest/v1/elastic-sip-trunking-service.ts
+++ b/packages/elastic-sip-trunking/src/rest/v1/elastic-sip-trunking-service.ts
@@ -5,6 +5,7 @@ import {
   LazyApiClient,
   SinchClientParameters,
   UnifiedCredentials,
+  resolveClientParameters,
 } from '@sinch/sdk-client';
 import { SipTrunksApi } from './sip-trunks';
 import { AccessControlListApi } from './access-control-list';
@@ -43,7 +44,8 @@ export class ElasticSipTrunkingService {
   public readonly lazyClient: LazyElasticSipTrunkingApiClient;
 
   constructor(params: SinchClientParameters) {
-    this.lazyClient = new LazyElasticSipTrunkingApiClient(params);
+    const resolvedParams = resolveClientParameters(params);
+    this.lazyClient = new LazyElasticSipTrunkingApiClient(resolvedParams);
 
     this.sipTrunks = new SipTrunksApi(this.lazyClient);
     this.sipEndpoints = new SipEndpointsApi(this.lazyClient);
@@ -54,6 +56,12 @@ export class ElasticSipTrunkingService {
     this.callBlockingRules = new CallBlockingRulesApi(this.lazyClient);
     this.credentialLists = new CredentialListsApi(this.lazyClient);
     this.phoneNumbers = new PhoneNumbersApi(this.lazyClient);
+  }
+
+  public setApiClientConfig(newParams: SinchClientParameters) {
+    const resolvedParams = resolveClientParameters(newParams);
+    this.lazyClient.sharedConfig = resolvedParams;
+    this.lazyClient.resetApiClient();
   }
 
   /**

--- a/packages/elastic-sip-trunking/src/rest/v1/elastic-sip-trunking-service.ts
+++ b/packages/elastic-sip-trunking/src/rest/v1/elastic-sip-trunking-service.ts
@@ -3,7 +3,6 @@ import {
   buildOAuth2ApiClientOptions,
   ELASTIC_SIP_TRUNKING_HOSTNAME,
   SinchClientParameters,
-  SinchLogger,
   UnifiedCredentials,
   resolveLogger,
 } from '@sinch/sdk-client';
@@ -85,7 +84,7 @@ export class ElasticSipTrunkingService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
+      this.lazyClient.sharedConfig.logger!.error(
         'Impossible to assign the new credentials to the Elastic SIP Trunking API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/elastic-sip-trunking/src/rest/v1/elastic-sip-trunking-service.ts
+++ b/packages/elastic-sip-trunking/src/rest/v1/elastic-sip-trunking-service.ts
@@ -3,6 +3,7 @@ import {
   buildOAuth2ApiClientOptions,
   ELASTIC_SIP_TRUNKING_HOSTNAME,
   SinchClientParameters,
+  SinchLogger,
   UnifiedCredentials,
 } from '@sinch/sdk-client';
 import { SipTrunksApi } from './sip-trunks';
@@ -82,7 +83,9 @@ export class ElasticSipTrunkingService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      console.error('Impossible to assign the new credentials to the Elastic SIP Trunking API');
+      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+        'Impossible to assign the new credentials to the Elastic SIP Trunking API',
+      );
       this.lazyClient.sharedConfig = parametersBackup;
       throw error;
     }

--- a/packages/elastic-sip-trunking/src/rest/v1/elastic-sip-trunking-service.ts
+++ b/packages/elastic-sip-trunking/src/rest/v1/elastic-sip-trunking-service.ts
@@ -5,6 +5,7 @@ import {
   SinchClientParameters,
   SinchLogger,
   UnifiedCredentials,
+  resolveLogger,
 } from '@sinch/sdk-client';
 import { SipTrunksApi } from './sip-trunks';
 import { AccessControlListApi } from './access-control-list';
@@ -50,6 +51,7 @@ export class ElasticSipTrunkingService {
   public readonly lazyClient: LazyElasticSipTrunkingApiClient;
 
   constructor(params: SinchClientParameters) {
+    params.logger = resolveLogger(params.logger);
     this.lazyClient = new LazyElasticSipTrunkingApiClient(params);
 
     this.sipTrunks = new SipTrunksApi(this.lazyClient);
@@ -83,7 +85,7 @@ export class ElasticSipTrunkingService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
         'Impossible to assign the new credentials to the Elastic SIP Trunking API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/elastic-sip-trunking/tests/rest/v1/access-control-list/access-control-list-api.test.ts
+++ b/packages/elastic-sip-trunking/tests/rest/v1/access-control-list/access-control-list-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   AccessControlListApi,
   AccessControlListApiFixture,
@@ -18,7 +18,7 @@ describe('AccessControlListApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyElasticSipTrunkingApiClient(credentials);
+    const lazyClient = new LazyElasticSipTrunkingApiClient(resolveClientParameters(credentials));
     accessControlListApi = new AccessControlListApi(lazyClient);
   });
 

--- a/packages/elastic-sip-trunking/tests/rest/v1/call-blocking-rules/call-blocking-rules-api.test.ts
+++ b/packages/elastic-sip-trunking/tests/rest/v1/call-blocking-rules/call-blocking-rules-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import { ElasticSipTrunking, LazyElasticSipTrunkingApiClient } from '../../../../src';
 import { CallBlockingRulesApi, CallBlockingRulesApiFixture } from '../../../../src';
 
@@ -14,7 +14,7 @@ describe('CallBlockingRulesApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyElasticSipTrunkingApiClient(credentials);
+    const lazyClient = new LazyElasticSipTrunkingApiClient(resolveClientParameters(credentials));
     callBlockingRulesApi = new CallBlockingRulesApi(lazyClient);
   });
 

--- a/packages/elastic-sip-trunking/tests/rest/v1/calls-history/calls-history-api.test.ts
+++ b/packages/elastic-sip-trunking/tests/rest/v1/calls-history/calls-history-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   CallsHistoryApi,
   CallsHistoryApiFixture,
@@ -19,7 +19,7 @@ describe('CallsApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyElasticSipTrunkingApiClient(credentials);
+    const lazyClient = new LazyElasticSipTrunkingApiClient(resolveClientParameters(credentials));
     callsApi = new CallsHistoryApi(lazyClient);
   });
 

--- a/packages/elastic-sip-trunking/tests/rest/v1/country-permissions/country-permissions-api.test.ts
+++ b/packages/elastic-sip-trunking/tests/rest/v1/country-permissions/country-permissions-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   CountryPermissionsApi,
   CountryPermissionsApiFixture,
@@ -18,7 +18,7 @@ describe('CountryPermissionsApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyElasticSipTrunkingApiClient(credentials);
+    const lazyClient = new LazyElasticSipTrunkingApiClient(resolveClientParameters(credentials));
     countryPermissionsApi = new CountryPermissionsApi(lazyClient);
   });
 

--- a/packages/elastic-sip-trunking/tests/rest/v1/credential-lists/credential-lists-api.test.ts
+++ b/packages/elastic-sip-trunking/tests/rest/v1/credential-lists/credential-lists-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   CredentialListsApi,
   CredentialListsApiFixture,
@@ -18,7 +18,7 @@ describe('CredentialListsApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyElasticSipTrunkingApiClient(credentials);
+    const lazyClient = new LazyElasticSipTrunkingApiClient(resolveClientParameters(credentials));
     credentialListsApi = new CredentialListsApi(lazyClient);
   });
 

--- a/packages/elastic-sip-trunking/tests/rest/v1/elastic-sip-trunking-domain-api.test.ts
+++ b/packages/elastic-sip-trunking/tests/rest/v1/elastic-sip-trunking-domain-api.test.ts
@@ -50,6 +50,7 @@ describe('Elastic SIP Trunking API', () => {
     expect(() => elasticSipTrunkingApi.setCredentials({ projectId: '' }))
       .toThrow('Invalid configuration for the Elastic SIP Trunking API: "projectId", "keyId" and "keySecret"'
         + ' values must be provided');
-    expect(errorSpy).toHaveBeenCalledWith('Impossible to assign the new credentials to the Elastic SIP Trunking API');
+    expect(errorSpy).toHaveBeenCalledWith('[Sinch SDK][Error] '
+      + 'Impossible to assign the new credentials to the Elastic SIP Trunking API');
   });
 });

--- a/packages/elastic-sip-trunking/tests/rest/v1/elastic-sip-trunking-domain-api.test.ts
+++ b/packages/elastic-sip-trunking/tests/rest/v1/elastic-sip-trunking-domain-api.test.ts
@@ -1,5 +1,5 @@
 import { ElasticSipTrunkingDomainApi, LazyElasticSipTrunkingApiClient } from '../../../src';
-import { ApiHostname, UnifiedCredentials } from '@sinch/sdk-client';
+import { ApiHostname, UnifiedCredentials, resolveClientParameters } from '@sinch/sdk-client';
 
 describe('Elastic SIP Trunking API', () => {
   let elasticSipTrunkingApi: ElasticSipTrunkingDomainApi;
@@ -14,7 +14,7 @@ describe('Elastic SIP Trunking API', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    lazyClient = new LazyElasticSipTrunkingApiClient(params);
+    lazyClient = new LazyElasticSipTrunkingApiClient(resolveClientParameters(params));
     errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 

--- a/packages/elastic-sip-trunking/tests/rest/v1/elastic-sip-trunking-domain-api.test.ts
+++ b/packages/elastic-sip-trunking/tests/rest/v1/elastic-sip-trunking-domain-api.test.ts
@@ -25,7 +25,7 @@ describe('Elastic SIP Trunking API', () => {
   });
 
   it('should use the hostname parameter', () => {
-    params.elasticSipTrunkingHostname = CUSTOM_HOSTNAME;
+    lazyClient.sharedConfig.elasticSipTrunkingHostname = CUSTOM_HOSTNAME;
     elasticSipTrunkingApi = new ElasticSipTrunkingDomainApi(lazyClient, 'dummy');
     expect(elasticSipTrunkingApi.client?.apiClientOptions.hostname).toBe(CUSTOM_HOSTNAME);
   });

--- a/packages/elastic-sip-trunking/tests/rest/v1/elastic-sip-trunking-service.test.ts
+++ b/packages/elastic-sip-trunking/tests/rest/v1/elastic-sip-trunking-service.test.ts
@@ -81,6 +81,29 @@ describe('Elastic SIP Trunking Service', () => {
     expect(elasticSipTrunkingService.phoneNumbers.client.apiClientOptions.hostname).toBe(CUSTOM_HOSTNAME);
   });
 
+  it('should update the API client configuration for all APIs', () => {
+    // Given
+    const params: SinchClientParameters = {
+      projectId: 'PROJECT_ID',
+      keyId: 'KEY_ID',
+      keySecret: 'KEY_SECRET',
+    };
+    const elasticSipTrunkingService = new ElasticSipTrunkingService(params);
+    const newApiClientConfig = {
+      projectId: 'NEW_PROJECT_ID',
+      keyId: 'NEW_KEY_ID',
+      keySecret: 'NEW_KEY_SECRET',
+    };
+
+    // When
+    elasticSipTrunkingService.setApiClientConfig(newApiClientConfig);
+
+    // Then
+    expect(elasticSipTrunkingService.lazyClient.sharedConfig.projectId).toBe('NEW_PROJECT_ID');
+    expect(elasticSipTrunkingService.lazyClient.sharedConfig.keyId).toBe('NEW_KEY_ID');
+    expect(elasticSipTrunkingService.lazyClient.sharedConfig.keySecret).toBe('NEW_KEY_SECRET');
+  });
+
   it('should set new credentials for all APIs', () => {
     // Given
     const params: SinchClientParameters = {

--- a/packages/elastic-sip-trunking/tests/rest/v1/elastic-sip-trunking-service.test.ts
+++ b/packages/elastic-sip-trunking/tests/rest/v1/elastic-sip-trunking-service.test.ts
@@ -117,7 +117,8 @@ describe('Elastic SIP Trunking Service', () => {
     expect(() => elasticSipTrunkingService.setCredentials({ projectId: '' }))
       .toThrow('Invalid configuration for the Elastic SIP Trunking API: "projectId", "keyId" and "keySecret"'
         + ' values must be provided');
-    expect(errorSpy).toHaveBeenCalledWith('Impossible to assign the new credentials to the Elastic SIP Trunking API');
+    expect(errorSpy).toHaveBeenCalledWith('[Sinch SDK][Error] '
+      + 'Impossible to assign the new credentials to the Elastic SIP Trunking API');
 
     // Then
     expect(elasticSipTrunkingService.sipTrunks.client.apiClientOptions.projectId).toBe('PROJECT_ID');

--- a/packages/elastic-sip-trunking/tests/rest/v1/phone-numbers/phone-numbers-api.test.ts
+++ b/packages/elastic-sip-trunking/tests/rest/v1/phone-numbers/phone-numbers-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   ElasticSipTrunking,
   LazyElasticSipTrunkingApiClient,
@@ -18,7 +18,7 @@ describe('PhoneNumbersApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyElasticSipTrunkingApiClient(credentials);
+    const lazyClient = new LazyElasticSipTrunkingApiClient(resolveClientParameters(credentials));
     phoneNumbersApi = new PhoneNumbersApi(lazyClient);
   });
 

--- a/packages/elastic-sip-trunking/tests/rest/v1/projects/projects-api.test.ts
+++ b/packages/elastic-sip-trunking/tests/rest/v1/projects/projects-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import { AddProjectsRequestData, AddProjectsResponse } from '../../../../src/models';
 import { ProjectsApi, ProjectsApiFixture } from '../../../../src/rest/v1/projects';
 import { LazyElasticSipTrunkingApiClient } from '../../../../src';
@@ -15,7 +15,7 @@ describe('ProjectsApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyElasticSipTrunkingApiClient(credentials);
+    const lazyClient = new LazyElasticSipTrunkingApiClient(resolveClientParameters(credentials));
     projectsApi = new ProjectsApi(lazyClient);
   });
 

--- a/packages/elastic-sip-trunking/tests/rest/v1/sip-endpoints/sip-endpoints-api.test.ts
+++ b/packages/elastic-sip-trunking/tests/rest/v1/sip-endpoints/sip-endpoints-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   SipEndpointsApi,
   SipEndpointsApiFixture,
@@ -19,7 +19,7 @@ describe('SIPEndpointsApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyElasticSipTrunkingApiClient(credentials);
+    const lazyClient = new LazyElasticSipTrunkingApiClient(resolveClientParameters(credentials));
     sipEndpointsApi = new SipEndpointsApi(lazyClient);
   });
 

--- a/packages/elastic-sip-trunking/tests/rest/v1/sip-trunks/sip-trunks-api.test.ts
+++ b/packages/elastic-sip-trunking/tests/rest/v1/sip-trunks/sip-trunks-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   SipTrunksApi,
   SipTrunksApiFixture,
@@ -18,7 +18,7 @@ describe('SIPTrunksApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyElasticSipTrunkingApiClient(credentials);
+    const lazyClient = new LazyElasticSipTrunkingApiClient(resolveClientParameters(credentials));
     sipTrunksApi = new SipTrunksApi(lazyClient);
   });
 

--- a/packages/fax/src/models/v3/helper.ts
+++ b/packages/fax/src/models/v3/helper.ts
@@ -1,12 +1,17 @@
 import { FaxBase64FileType, validBase64FileTypes } from './enums';
+import { Logger, SinchLogger, resolveLogger } from '@sinch/sdk-client';
 
-export const convertToSupportedFileType = (fileType: string | undefined): FaxBase64FileType | undefined => {
+export const convertToSupportedFileType = (
+  fileType: string | undefined,
+  logger?: Logger | null,
+): FaxBase64FileType | undefined => {
+  const sinchLogger = new SinchLogger(resolveLogger(logger));
   if (!fileType) {
-    console.warn('No file extension has been defined.');
+    sinchLogger.warn('No file extension has been defined.');
     return undefined;
   }
   if (!validBase64FileTypes.includes(fileType.toUpperCase() as FaxBase64FileType)) {
-    console.warn(`The file extension "${fileType.toUpperCase()}" is not supported.`);
+    sinchLogger.warn(`The file extension "${fileType.toUpperCase()}" is not supported.`);
   }
   return fileType.toUpperCase() as FaxBase64FileType;
 };

--- a/packages/fax/src/models/v3/helper.ts
+++ b/packages/fax/src/models/v3/helper.ts
@@ -1,17 +1,10 @@
-import { FaxBase64FileType, validBase64FileTypes } from './enums';
-import { Logger, SinchLogger, resolveLogger } from '@sinch/sdk-client';
+import { FaxBase64FileType } from './enums';
 
 export const convertToSupportedFileType = (
   fileType: string | undefined,
-  logger?: Logger | null,
 ): FaxBase64FileType | undefined => {
-  const sinchLogger = new SinchLogger(resolveLogger(logger));
   if (!fileType) {
-    sinchLogger.warn('No file extension has been defined.');
     return undefined;
-  }
-  if (!validBase64FileTypes.includes(fileType.toUpperCase() as FaxBase64FileType)) {
-    sinchLogger.warn(`The file extension "${fileType.toUpperCase()}" is not supported.`);
   }
   return fileType.toUpperCase() as FaxBase64FileType;
 };

--- a/packages/fax/src/rest/v3/callbacks/callbacks-webhook.ts
+++ b/packages/fax/src/rest/v3/callbacks/callbacks-webhook.ts
@@ -42,8 +42,7 @@ export class FaxCallbackWebhooks implements CallbackProcessor<FaxWebhookEventPar
           throw new Error(`Unknown Fax event: ${eventBody.event}`);
       }
     }
-    console.log(eventBody);
-    throw new Error('Unknown Fax event');
+    throw new Error(`Unknown Fax event: ${JSON.stringify(eventBody)}`);
   }
 
   private reviveFax(faxAsString: string): Fax {

--- a/packages/fax/src/rest/v3/fax-domain-api.ts
+++ b/packages/fax/src/rest/v3/fax-domain-api.ts
@@ -1,6 +1,7 @@
 import {
   Api, ApiClient,
   FaxRegion,
+  SinchLogger,
   UnifiedCredentials,
 } from '@sinch/sdk-client';
 import { LazyFaxApiClient } from './fax-service';
@@ -61,7 +62,9 @@ export class FaxDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      console.error('Impossible to assign the new credentials to the Fax API');
+      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+        'Impossible to assign the new credentials to the Fax API',
+      );
       this.lazyClient.sharedConfig = parametersBackup;
       throw error;
     }

--- a/packages/fax/src/rest/v3/fax-domain-api.ts
+++ b/packages/fax/src/rest/v3/fax-domain-api.ts
@@ -3,6 +3,7 @@ import {
   FaxRegion,
   SinchLogger,
   UnifiedCredentials,
+  resolveLogger,
 } from '@sinch/sdk-client';
 import { LazyFaxApiClient } from './fax-service';
 
@@ -45,7 +46,7 @@ export class FaxDomainApi implements Api {
     // Deprecated: regions are ignored by the Fax API which uses a single global endpoint.
     // Keep this method for backward compatibility but avoid mutating shared state or
     // resetting the client to prevent unexpected side effects.
-    console.info(`Deprecated: The regions are not used for the Fax API, the request will be perform against the global endpoint ${this.lazyClient.sharedConfig.faxHostname ?? 'https://fax.api.sinch.com'}`);
+    new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).info(`Deprecated: The regions are not used for the Fax API, the request will be perform against the global endpoint ${this.lazyClient.sharedConfig.faxHostname ?? 'https://fax.api.sinch.com'}`);
   }
 
   /**
@@ -62,7 +63,7 @@ export class FaxDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
         'Impossible to assign the new credentials to the Fax API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/fax/src/rest/v3/fax-domain-api.ts
+++ b/packages/fax/src/rest/v3/fax-domain-api.ts
@@ -1,9 +1,7 @@
 import {
   Api, ApiClient,
   FaxRegion,
-  SinchLogger,
   UnifiedCredentials,
-  resolveLogger,
 } from '@sinch/sdk-client';
 import { LazyFaxApiClient } from './fax-service';
 
@@ -46,7 +44,7 @@ export class FaxDomainApi implements Api {
     // Deprecated: regions are ignored by the Fax API which uses a single global endpoint.
     // Keep this method for backward compatibility but avoid mutating shared state or
     // resetting the client to prevent unexpected side effects.
-    new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).info(`Deprecated: The regions are not used for the Fax API, the request will be perform against the global endpoint ${this.lazyClient.sharedConfig.faxHostname ?? 'https://fax.api.sinch.com'}`);
+    this.lazyClient.sharedConfig.logger!.info(`Deprecated: The regions are not used for the Fax API, the request will be perform against the global endpoint ${this.lazyClient.sharedConfig.faxHostname ?? 'https://fax.api.sinch.com'}`);
   }
 
   /**
@@ -63,7 +61,7 @@ export class FaxDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
+      this.lazyClient.sharedConfig.logger!.error(
         'Impossible to assign the new credentials to the Fax API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/fax/src/rest/v3/fax-domain-api.ts
+++ b/packages/fax/src/rest/v3/fax-domain-api.ts
@@ -44,7 +44,7 @@ export class FaxDomainApi implements Api {
     // Deprecated: regions are ignored by the Fax API which uses a single global endpoint.
     // Keep this method for backward compatibility but avoid mutating shared state or
     // resetting the client to prevent unexpected side effects.
-    this.lazyClient.sharedConfig.logger!.info(`Deprecated: The regions are not used for the Fax API, the request will be perform against the global endpoint ${this.lazyClient.sharedConfig.faxHostname ?? 'https://fax.api.sinch.com'}`);
+    this.lazyClient.sharedConfig.logger.info(`Deprecated: The regions are not used for the Fax API, the request will be perform against the global endpoint ${this.lazyClient.sharedConfig.faxHostname ?? 'https://fax.api.sinch.com'}`);
   }
 
   /**
@@ -61,7 +61,7 @@ export class FaxDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      this.lazyClient.sharedConfig.logger!.error(
+      this.lazyClient.sharedConfig.logger.error(
         'Impossible to assign the new credentials to the Fax API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/fax/src/rest/v3/fax-service.ts
+++ b/packages/fax/src/rest/v3/fax-service.ts
@@ -4,6 +4,7 @@ import {
   FAX_HOSTNAME,
   FaxRegion,
   SinchClientParameters,
+  SinchLogger,
   UnifiedCredentials,
 } from '@sinch/sdk-client';
 import { FaxToEmailApi } from './fax-to-email';
@@ -94,7 +95,9 @@ export class FaxService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      console.error('Impossible to assign the new credentials to the Fax API');
+      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+        'Impossible to assign the new credentials to the Fax API',
+      );
       this.lazyClient.sharedConfig = parametersBackup;
       throw error;
     }

--- a/packages/fax/src/rest/v3/fax-service.ts
+++ b/packages/fax/src/rest/v3/fax-service.ts
@@ -5,17 +5,15 @@ import {
   FaxRegion,
   SinchClientParameters,
   UnifiedCredentials,
-  resolveLogger,
+  LazyApiClient,
+  resolveClientParameters,
 } from '@sinch/sdk-client';
 import { FaxToEmailApi } from './fax-to-email';
 import { FaxesApi } from './faxes';
 import { ServicesApi } from './services';
 import { CoverPagesApi } from './cover-pages';
 
-export class LazyFaxApiClient {
-  apiFetchClient?: ApiFetchClient;
-  constructor(public sharedConfig: SinchClientParameters) {}
-
+export class LazyFaxApiClient extends LazyApiClient {
   public getApiClient(): ApiFetchClient {
     if (!this.apiFetchClient) {
       const apiClientOptions = buildOAuth2ApiClientOptions(this.sharedConfig, 'Fax');
@@ -24,10 +22,6 @@ export class LazyFaxApiClient {
       this.apiFetchClient.apiClientOptions.hostname = this.sharedConfig.faxHostname ?? FAX_HOSTNAME;
     }
     return this.apiFetchClient;
-  }
-
-  public resetApiClient() {
-    this.apiFetchClient = undefined;
   }
 }
 
@@ -49,7 +43,6 @@ export class FaxService {
   public readonly lazyClient: LazyFaxApiClient;
 
   constructor(params: SinchClientParameters) {
-    params.logger = resolveLogger(params.logger);
     this.lazyClient = new LazyFaxApiClient(params);
 
     this.emails = new FaxToEmailApi(this.lazyClient);
@@ -60,7 +53,7 @@ export class FaxService {
   }
 
   public setApiClientConfig(newParams: SinchClientParameters) {
-    this.lazyClient.sharedConfig = newParams;
+    this.lazyClient.sharedConfig = resolveClientParameters(newParams);
     this.lazyClient.resetApiClient();
   }
 
@@ -83,7 +76,7 @@ export class FaxService {
     // Deprecated: regions are ignored by the Fax API which uses a single global endpoint.
     // Keep this method for backward compatibility but avoid mutating shared state or
     // resetting the client to prevent unexpected side effects.
-    this.lazyClient.sharedConfig.logger!.info(`Deprecated: The regions are not used for the Fax API, the request will be perform against the global endpoint ${FAX_HOSTNAME}`);
+    this.lazyClient.sharedConfig.logger.info(`Deprecated: The regions are not used for the Fax API, the request will be perform against the global endpoint ${FAX_HOSTNAME}`);
   }
 
   public setCredentials(credentials: Partial<UnifiedCredentials>): void {
@@ -96,7 +89,7 @@ export class FaxService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      this.lazyClient.sharedConfig.logger!.error(
+      this.lazyClient.sharedConfig.logger.error(
         'Impossible to assign the new credentials to the Fax API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/fax/src/rest/v3/fax-service.ts
+++ b/packages/fax/src/rest/v3/fax-service.ts
@@ -4,7 +4,6 @@ import {
   FAX_HOSTNAME,
   FaxRegion,
   SinchClientParameters,
-  SinchLogger,
   UnifiedCredentials,
   resolveLogger,
 } from '@sinch/sdk-client';
@@ -84,7 +83,7 @@ export class FaxService {
     // Deprecated: regions are ignored by the Fax API which uses a single global endpoint.
     // Keep this method for backward compatibility but avoid mutating shared state or
     // resetting the client to prevent unexpected side effects.
-    new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).info(`Deprecated: The regions are not used for the Fax API, the request will be perform against the global endpoint ${FAX_HOSTNAME}`);
+    this.lazyClient.sharedConfig.logger!.info(`Deprecated: The regions are not used for the Fax API, the request will be perform against the global endpoint ${FAX_HOSTNAME}`);
   }
 
   public setCredentials(credentials: Partial<UnifiedCredentials>): void {
@@ -97,7 +96,7 @@ export class FaxService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
+      this.lazyClient.sharedConfig.logger!.error(
         'Impossible to assign the new credentials to the Fax API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/fax/src/rest/v3/fax-service.ts
+++ b/packages/fax/src/rest/v3/fax-service.ts
@@ -43,7 +43,8 @@ export class FaxService {
   public readonly lazyClient: LazyFaxApiClient;
 
   constructor(params: SinchClientParameters) {
-    this.lazyClient = new LazyFaxApiClient(params);
+    const resolvedParams = resolveClientParameters(params);
+    this.lazyClient = new LazyFaxApiClient(resolvedParams);
 
     this.emails = new FaxToEmailApi(this.lazyClient);
     this.faxToEmail = new FaxToEmailApi(this.lazyClient);
@@ -53,7 +54,8 @@ export class FaxService {
   }
 
   public setApiClientConfig(newParams: SinchClientParameters) {
-    this.lazyClient.sharedConfig = resolveClientParameters(newParams);
+    const resolvedParams = resolveClientParameters(newParams);
+    this.lazyClient.sharedConfig = resolvedParams;
     this.lazyClient.resetApiClient();
   }
 

--- a/packages/fax/src/rest/v3/fax-service.ts
+++ b/packages/fax/src/rest/v3/fax-service.ts
@@ -6,6 +6,7 @@ import {
   SinchClientParameters,
   SinchLogger,
   UnifiedCredentials,
+  resolveLogger,
 } from '@sinch/sdk-client';
 import { FaxToEmailApi } from './fax-to-email';
 import { FaxesApi } from './faxes';
@@ -49,6 +50,7 @@ export class FaxService {
   public readonly lazyClient: LazyFaxApiClient;
 
   constructor(params: SinchClientParameters) {
+    params.logger = resolveLogger(params.logger);
     this.lazyClient = new LazyFaxApiClient(params);
 
     this.emails = new FaxToEmailApi(this.lazyClient);
@@ -82,7 +84,7 @@ export class FaxService {
     // Deprecated: regions are ignored by the Fax API which uses a single global endpoint.
     // Keep this method for backward compatibility but avoid mutating shared state or
     // resetting the client to prevent unexpected side effects.
-    console.info(`Deprecated: The regions are not used for the Fax API, the request will be perform against the global endpoint ${FAX_HOSTNAME}`);
+    new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).info(`Deprecated: The regions are not used for the Fax API, the request will be perform against the global endpoint ${FAX_HOSTNAME}`);
   }
 
   public setCredentials(credentials: Partial<UnifiedCredentials>): void {
@@ -95,7 +97,7 @@ export class FaxService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
         'Impossible to assign the new credentials to the Fax API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/fax/src/rest/v3/faxes/faxes-api.ts
+++ b/packages/fax/src/rest/v3/faxes/faxes-api.ts
@@ -8,6 +8,8 @@ import {
   PaginatedApiProperties,
   PaginationEnum,
   RequestBody,
+  SinchLogger,
+  resolveLogger,
 } from '@sinch/sdk-client';
 import { FaxDomainApi } from '../fax-domain-api';
 import {
@@ -78,7 +80,7 @@ export class FaxesApi extends FaxDomainApi {
     let basePathUrl: string;
     let operationId: string;
     if (data['fileFormat'] !== undefined) {
-      console.info('Deprecated: The fileFormat path parameter is deprecated. Use downloadContent without fileFormat. See https://developers.sinch.com/docs/fax/api-reference/fax/faxes/getfaxfilebyid');
+      new SinchLogger(resolveLogger(this.client.apiClientOptions.logger)).info('Deprecated: The fileFormat path parameter is deprecated. Use downloadContent without fileFormat. See https://developers.sinch.com/docs/fax/api-reference/fax/faxes/getfaxfilebyid');
       basePathUrl = `${filePath}.${data['fileFormat']}`;
       operationId = 'GetFaxFileByIdDeprecated';
     } else {

--- a/packages/fax/src/rest/v3/faxes/faxes-api.ts
+++ b/packages/fax/src/rest/v3/faxes/faxes-api.ts
@@ -8,8 +8,6 @@ import {
   PaginatedApiProperties,
   PaginationEnum,
   RequestBody,
-  SinchLogger,
-  resolveLogger,
 } from '@sinch/sdk-client';
 import { FaxDomainApi } from '../fax-domain-api';
 import {
@@ -80,7 +78,7 @@ export class FaxesApi extends FaxDomainApi {
     let basePathUrl: string;
     let operationId: string;
     if (data['fileFormat'] !== undefined) {
-      new SinchLogger(resolveLogger(this.client.apiClientOptions.logger)).info('Deprecated: The fileFormat path parameter is deprecated. Use downloadContent without fileFormat. See https://developers.sinch.com/docs/fax/api-reference/fax/faxes/getfaxfilebyid');
+      this.client.apiClientOptions.logger!.info('Deprecated: The fileFormat path parameter is deprecated. Use downloadContent without fileFormat. See https://developers.sinch.com/docs/fax/api-reference/fax/faxes/getfaxfilebyid');
       basePathUrl = `${filePath}.${data['fileFormat']}`;
       operationId = 'GetFaxFileByIdDeprecated';
     } else {

--- a/packages/fax/tests/models/v3/helper.test.ts
+++ b/packages/fax/tests/models/v3/helper.test.ts
@@ -4,9 +4,9 @@ describe('Fax models helpers', () => {
 
   describe('convertToSupportedFileType', () => {
     it('should convert a file extension to a FaxBase64FileType', () => {
-      console.warn = jest.fn();
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       let convertedFileExtension = convertToSupportedFileType('doc');
-      expect(console.warn).toHaveBeenCalledWith('The file extension "DOC" is not supported.');
+      expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] The file extension "DOC" is not supported.');
       expect(convertedFileExtension).toBe('DOC');
 
       convertedFileExtension = convertToSupportedFileType('docx');
@@ -34,12 +34,13 @@ describe('Fax models helpers', () => {
       expect(convertedFileExtension).toBe('PNG');
 
       convertedFileExtension = convertToSupportedFileType(undefined);
-      expect(console.warn).toHaveBeenCalledWith('No file extension has been defined.');
+      expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] No file extension has been defined.');
       expect(convertedFileExtension).toBeUndefined();
 
       convertedFileExtension = convertToSupportedFileType('unknown');
-      expect(console.warn).toHaveBeenCalledWith('The file extension "UNKNOWN" is not supported.');
+      expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] The file extension "UNKNOWN" is not supported.');
       expect(convertedFileExtension).toBe('UNKNOWN');
+      warnSpy.mockRestore();
     });
   });
 

--- a/packages/fax/tests/models/v3/helper.test.ts
+++ b/packages/fax/tests/models/v3/helper.test.ts
@@ -4,43 +4,17 @@ describe('Fax models helpers', () => {
 
   describe('convertToSupportedFileType', () => {
     it('should convert a file extension to a FaxBase64FileType', () => {
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-      let convertedFileExtension = convertToSupportedFileType('doc');
-      expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] The file extension "DOC" is not supported.');
-      expect(convertedFileExtension).toBe('DOC');
-
-      convertedFileExtension = convertToSupportedFileType('docx');
-      expect(convertedFileExtension).toBe('DOCX');
-
-      convertedFileExtension = convertToSupportedFileType('pdf');
-      expect(convertedFileExtension).toBe('PDF');
-
-      convertedFileExtension = convertToSupportedFileType('tif');
-      expect(convertedFileExtension).toBe('TIF');
-
-      convertedFileExtension = convertToSupportedFileType('jpg');
-      expect(convertedFileExtension).toBe('JPG');
-
-      convertedFileExtension = convertToSupportedFileType('odt');
-      expect(convertedFileExtension).toBe('ODT');
-
-      convertedFileExtension = convertToSupportedFileType('txt');
-      expect(convertedFileExtension).toBe('TXT');
-
-      convertedFileExtension = convertToSupportedFileType('html');
-      expect(convertedFileExtension).toBe('HTML');
-
-      convertedFileExtension = convertToSupportedFileType('png');
-      expect(convertedFileExtension).toBe('PNG');
-
-      convertedFileExtension = convertToSupportedFileType(undefined);
-      expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] No file extension has been defined.');
-      expect(convertedFileExtension).toBeUndefined();
-
-      convertedFileExtension = convertToSupportedFileType('unknown');
-      expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] The file extension "UNKNOWN" is not supported.');
-      expect(convertedFileExtension).toBe('UNKNOWN');
-      warnSpy.mockRestore();
+      expect(convertToSupportedFileType('doc')).toBe('DOC');
+      expect(convertToSupportedFileType('docx')).toBe('DOCX');
+      expect(convertToSupportedFileType('pdf')).toBe('PDF');
+      expect(convertToSupportedFileType('tif')).toBe('TIF');
+      expect(convertToSupportedFileType('jpg')).toBe('JPG');
+      expect(convertToSupportedFileType('odt')).toBe('ODT');
+      expect(convertToSupportedFileType('txt')).toBe('TXT');
+      expect(convertToSupportedFileType('html')).toBe('HTML');
+      expect(convertToSupportedFileType('png')).toBe('PNG');
+      expect(convertToSupportedFileType(undefined)).toBeUndefined();
+      expect(convertToSupportedFileType('unknown')).toBe('UNKNOWN');
     });
   });
 

--- a/packages/fax/tests/rest/v3/cover-pages/cover-pages-api.test.ts
+++ b/packages/fax/tests/rest/v3/cover-pages/cover-pages-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   CoverPagesApi,
   CoverPagesApiFixture,
@@ -18,7 +18,7 @@ describe('CoverPagesApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyFaxApiClient(credentials);
+    const lazyClient = new LazyFaxApiClient(resolveClientParameters(credentials));
     coverPagesApi = new CoverPagesApi(lazyClient);
   });
 

--- a/packages/fax/tests/rest/v3/fax-domain-api.test.ts
+++ b/packages/fax/tests/rest/v3/fax-domain-api.test.ts
@@ -25,7 +25,7 @@ describe('Fax API', () => {
   });
 
   it('should use the hostname parameter', () => {
-    params.faxHostname = CUSTOM_HOSTNAME;
+    lazyClient.sharedConfig.faxHostname = CUSTOM_HOSTNAME;
     faxApi = new FaxDomainApi(lazyClient, 'dummy');
     expect(faxApi.client?.apiClientOptions.hostname).toBe(CUSTOM_HOSTNAME);
   });

--- a/packages/fax/tests/rest/v3/fax-domain-api.test.ts
+++ b/packages/fax/tests/rest/v3/fax-domain-api.test.ts
@@ -72,7 +72,8 @@ describe('Fax API', () => {
     expect(() => faxApi.setCredentials({ projectId: '' }))
       .toThrow('Invalid configuration for the Fax API: "projectId", "keyId" and "keySecret"'
         + ' values must be provided');
-    expect(errorSpy).toHaveBeenCalledWith('Impossible to assign the new credentials to the Fax API');
+    expect(errorSpy).toHaveBeenCalledWith('[Sinch SDK][Error] '
+      + 'Impossible to assign the new credentials to the Fax API');
   });
 
 });

--- a/packages/fax/tests/rest/v3/fax-domain-api.test.ts
+++ b/packages/fax/tests/rest/v3/fax-domain-api.test.ts
@@ -1,5 +1,5 @@
 import { FaxDomainApi, LazyFaxApiClient } from '../../../src';
-import { ApiHostname, FaxRegion, UnifiedCredentials } from '@sinch/sdk-client';
+import { ApiHostname, FaxRegion, UnifiedCredentials, resolveClientParameters } from '@sinch/sdk-client';
 
 describe('Fax API', () => {
   let faxApi: FaxDomainApi;
@@ -14,7 +14,7 @@ describe('Fax API', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    lazyClient = new LazyFaxApiClient(params);
+    lazyClient = new LazyFaxApiClient(resolveClientParameters(params));
     errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 

--- a/packages/fax/tests/rest/v3/fax-domain-api.test.ts
+++ b/packages/fax/tests/rest/v3/fax-domain-api.test.ts
@@ -47,11 +47,11 @@ describe('Fax API', () => {
     faxApi.setRegion(FaxRegion.UNITED_STATES);
     expect(faxApi.client?.apiClientOptions.hostname).toBe('https://fax.api.sinch.com');
     expect(infoSpy).toHaveBeenCalledWith(
-      'Deprecated: The regions are not used for the Fax API, the request will be perform against the global endpoint https://fax.api.sinch.com');
+      '[Sinch SDK][Info] Deprecated: The regions are not used for the Fax API, the request will be perform against the global endpoint https://fax.api.sinch.com');
     faxApi.setRegion(FaxRegion.EUROPE);
     expect(faxApi.client?.apiClientOptions.hostname).toBe('https://fax.api.sinch.com');
     expect(infoSpy).toHaveBeenCalledWith(
-      'Deprecated: The regions are not used for the Fax API, the request will be perform against the global endpoint https://fax.api.sinch.com');
+      '[Sinch SDK][Info] Deprecated: The regions are not used for the Fax API, the request will be perform against the global endpoint https://fax.api.sinch.com');
     faxApi.setRegion('');
     expect(faxApi.client?.apiClientOptions.hostname).toBe('https://fax.api.sinch.com');
     infoSpy.mockRestore();

--- a/packages/fax/tests/rest/v3/fax-service.test.ts
+++ b/packages/fax/tests/rest/v3/fax-service.test.ts
@@ -145,7 +145,7 @@ describe('Fax Service', () => {
     // Then
     // Fax API is global: setRegion is deprecated and should not change the hostname.
     expect(infoSpy).toHaveBeenCalledWith(
-      `Deprecated: The regions are not used for the Fax API, the request will be perform against the global endpoint ${DEFAULT_HOSTNAME}`,
+      `[Sinch SDK][Info] Deprecated: The regions are not used for the Fax API, the request will be perform against the global endpoint ${DEFAULT_HOSTNAME}`,
     );
     expect(faxService.faxes.client.apiClientOptions.hostname).toBe(DEFAULT_HOSTNAME);
     expect(faxService.faxToEmail.client.apiClientOptions.hostname).toBe(DEFAULT_HOSTNAME);

--- a/packages/fax/tests/rest/v3/fax-service.test.ts
+++ b/packages/fax/tests/rest/v3/fax-service.test.ts
@@ -190,7 +190,8 @@ describe('Fax Service', () => {
     expect(() => faxService.setCredentials({ projectId: '' }))
       .toThrow('Invalid configuration for the Fax API: "projectId", "keyId" and "keySecret"'
         + ' values must be provided');
-    expect(errorSpy).toHaveBeenCalledWith('Impossible to assign the new credentials to the Fax API');
+    expect(errorSpy).toHaveBeenCalledWith('[Sinch SDK][Error] '
+      + 'Impossible to assign the new credentials to the Fax API');
 
     // Then
     expect(faxService.faxes.client.apiClientOptions.projectId).toBe('PROJECT_ID');

--- a/packages/fax/tests/rest/v3/fax-to-email/fax-to-email-api.test.ts
+++ b/packages/fax/tests/rest/v3/fax-to-email/fax-to-email-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import { Fax, LazyFaxApiClient } from '../../../../src';
 import { FaxToEmailApi, FaxToEmailApiFixture } from '../../../../src';
 
@@ -14,7 +14,7 @@ describe('EmailsApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyFaxApiClient(credentials);
+    const lazyClient = new LazyFaxApiClient(resolveClientParameters(credentials));
     faxToEmailApi = new FaxToEmailApi(lazyClient);
   });
 

--- a/packages/fax/tests/rest/v3/faxes/faxes-api.test.ts
+++ b/packages/fax/tests/rest/v3/faxes/faxes-api.test.ts
@@ -1,4 +1,4 @@
-import { FileBuffer, SinchClientParameters } from '@sinch/sdk-client';
+import { FileBuffer, SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   Fax,
   FaxesApi,
@@ -18,7 +18,7 @@ describe('FaxesApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyFaxApiClient(credentials);
+    const lazyClient = new LazyFaxApiClient(resolveClientParameters(credentials));
     faxesApi = new FaxesApi(lazyClient);
   });
 

--- a/packages/fax/tests/rest/v3/services/services-api.test.ts
+++ b/packages/fax/tests/rest/v3/services/services-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   ServicesApi,
   ServicesApiFixture,
@@ -18,7 +18,7 @@ describe('ServicesApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyFaxApiClient(credentials);
+    const lazyClient = new LazyFaxApiClient(resolveClientParameters(credentials));
     servicesApi = new ServicesApi(lazyClient);
   });
 

--- a/packages/number-lookup/src/rest/v2/number-lookup-domain-api.ts
+++ b/packages/number-lookup/src/rest/v2/number-lookup-domain-api.ts
@@ -3,6 +3,7 @@ import {
   ApiClient,
   SinchLogger,
   UnifiedCredentials,
+  resolveLogger,
 } from '@sinch/sdk-client';
 import { LazyNumberLookupApiClient } from './number-lookup-service';
 
@@ -40,7 +41,7 @@ export class NumberLookupDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
         'Impossible to assign the new credentials to the Number Lookup API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/number-lookup/src/rest/v2/number-lookup-domain-api.ts
+++ b/packages/number-lookup/src/rest/v2/number-lookup-domain-api.ts
@@ -1,9 +1,7 @@
 import {
   Api,
   ApiClient,
-  SinchLogger,
   UnifiedCredentials,
-  resolveLogger,
 } from '@sinch/sdk-client';
 import { LazyNumberLookupApiClient } from './number-lookup-service';
 
@@ -41,7 +39,7 @@ export class NumberLookupDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
+      this.lazyClient.sharedConfig.logger!.error(
         'Impossible to assign the new credentials to the Number Lookup API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/number-lookup/src/rest/v2/number-lookup-domain-api.ts
+++ b/packages/number-lookup/src/rest/v2/number-lookup-domain-api.ts
@@ -1,6 +1,7 @@
 import {
   Api,
   ApiClient,
+  SinchLogger,
   UnifiedCredentials,
 } from '@sinch/sdk-client';
 import { LazyNumberLookupApiClient } from './number-lookup-service';
@@ -39,7 +40,9 @@ export class NumberLookupDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      console.error('Impossible to assign the new credentials to the Number Lookup API');
+      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+        'Impossible to assign the new credentials to the Number Lookup API',
+      );
       this.lazyClient.sharedConfig = parametersBackup;
       throw error;
     }

--- a/packages/number-lookup/src/rest/v2/number-lookup-domain-api.ts
+++ b/packages/number-lookup/src/rest/v2/number-lookup-domain-api.ts
@@ -39,7 +39,7 @@ export class NumberLookupDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      this.lazyClient.sharedConfig.logger!.error(
+      this.lazyClient.sharedConfig.logger.error(
         'Impossible to assign the new credentials to the Number Lookup API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/number-lookup/src/rest/v2/number-lookup-service.ts
+++ b/packages/number-lookup/src/rest/v2/number-lookup-service.ts
@@ -3,7 +3,6 @@ import {
   buildOAuth2ApiClientOptions,
   NUMBER_LOOKUP_HOSTNAME,
   SinchClientParameters,
-  SinchLogger,
   UnifiedCredentials,
   resolveLogger,
 } from '@sinch/sdk-client';
@@ -66,7 +65,7 @@ export class NumberLookupService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
+      this.lazyClient.sharedConfig.logger!.error(
         'Impossible to assign the new credentials to the Number Lookup API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/number-lookup/src/rest/v2/number-lookup-service.ts
+++ b/packages/number-lookup/src/rest/v2/number-lookup-service.ts
@@ -2,17 +2,15 @@ import {
   ApiFetchClient,
   buildOAuth2ApiClientOptions,
   NUMBER_LOOKUP_HOSTNAME,
+  LazyApiClient,
   SinchClientParameters,
   UnifiedCredentials,
-  resolveLogger,
+  resolveClientParameters,
 } from '@sinch/sdk-client';
 import { NumberLookupApi } from './number-lookup';
 import { NumberLookupRequestData, NumberLookupResponse } from '../../models';
 
-export class LazyNumberLookupApiClient {
-  apiFetchClient?: ApiFetchClient;
-  constructor(public sharedConfig: SinchClientParameters) {}
-
+export class LazyNumberLookupApiClient extends LazyApiClient {
   public getApiClient(): ApiFetchClient {
     if (!this.apiFetchClient) {
       const apiClientOptions = buildOAuth2ApiClientOptions(this.sharedConfig, 'Number Lookup');
@@ -20,10 +18,6 @@ export class LazyNumberLookupApiClient {
       this.apiFetchClient.apiClientOptions.hostname = this.sharedConfig.numberLookupHostname ?? NUMBER_LOOKUP_HOSTNAME;
     }
     return this.apiFetchClient;
-  }
-
-  public resetApiClient() {
-    this.apiFetchClient = undefined;
   }
 }
 
@@ -33,7 +27,6 @@ export class NumberLookupService {
   public readonly lazyClient: LazyNumberLookupApiClient;
 
   constructor(params: SinchClientParameters) {
-    params.logger = resolveLogger(params.logger);
     const sharedClient = new LazyNumberLookupApiClient(params);
     this.lazyClient = sharedClient;
 
@@ -41,7 +34,7 @@ export class NumberLookupService {
   }
 
   public setApiClientConfig(newParams: SinchClientParameters) {
-    this.lazyClient.sharedConfig = newParams;
+    this.lazyClient.sharedConfig = resolveClientParameters(newParams);
     this.lazyClient.resetApiClient();
   }
 
@@ -65,7 +58,7 @@ export class NumberLookupService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      this.lazyClient.sharedConfig.logger!.error(
+      this.lazyClient.sharedConfig.logger.error(
         'Impossible to assign the new credentials to the Number Lookup API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/number-lookup/src/rest/v2/number-lookup-service.ts
+++ b/packages/number-lookup/src/rest/v2/number-lookup-service.ts
@@ -27,14 +27,16 @@ export class NumberLookupService {
   public readonly lazyClient: LazyNumberLookupApiClient;
 
   constructor(params: SinchClientParameters) {
-    const sharedClient = new LazyNumberLookupApiClient(params);
+    const resolvedParams = resolveClientParameters(params);
+    const sharedClient = new LazyNumberLookupApiClient(resolvedParams);
     this.lazyClient = sharedClient;
 
     this._numberLookup = new NumberLookupApi(sharedClient);
   }
 
   public setApiClientConfig(newParams: SinchClientParameters) {
-    this.lazyClient.sharedConfig = resolveClientParameters(newParams);
+    const resolvedParams = resolveClientParameters(newParams);
+    this.lazyClient.sharedConfig = resolvedParams;
     this.lazyClient.resetApiClient();
   }
 

--- a/packages/number-lookup/src/rest/v2/number-lookup-service.ts
+++ b/packages/number-lookup/src/rest/v2/number-lookup-service.ts
@@ -3,6 +3,7 @@ import {
   buildOAuth2ApiClientOptions,
   NUMBER_LOOKUP_HOSTNAME,
   SinchClientParameters,
+  SinchLogger,
   UnifiedCredentials,
 } from '@sinch/sdk-client';
 import { NumberLookupApi } from './number-lookup';
@@ -63,7 +64,9 @@ export class NumberLookupService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      console.error('Impossible to assign the new credentials to the Number Lookup API');
+      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+        'Impossible to assign the new credentials to the Number Lookup API',
+      );
       this.lazyClient.sharedConfig = parametersBackup;
       throw error;
     }

--- a/packages/number-lookup/src/rest/v2/number-lookup-service.ts
+++ b/packages/number-lookup/src/rest/v2/number-lookup-service.ts
@@ -5,6 +5,7 @@ import {
   SinchClientParameters,
   SinchLogger,
   UnifiedCredentials,
+  resolveLogger,
 } from '@sinch/sdk-client';
 import { NumberLookupApi } from './number-lookup';
 import { NumberLookupRequestData, NumberLookupResponse } from '../../models';
@@ -33,6 +34,7 @@ export class NumberLookupService {
   public readonly lazyClient: LazyNumberLookupApiClient;
 
   constructor(params: SinchClientParameters) {
+    params.logger = resolveLogger(params.logger);
     const sharedClient = new LazyNumberLookupApiClient(params);
     this.lazyClient = sharedClient;
 
@@ -64,7 +66,7 @@ export class NumberLookupService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
         'Impossible to assign the new credentials to the Number Lookup API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/number-lookup/tests/rest/v2/number-lookup-domain.test.ts
+++ b/packages/number-lookup/tests/rest/v2/number-lookup-domain.test.ts
@@ -1,5 +1,5 @@
 import { NumberLookupDomainApi, LazyNumberLookupApiClient } from '../../../src';
-import { ApiHostname, UnifiedCredentials } from '@sinch/sdk-client';
+import { ApiHostname, UnifiedCredentials, resolveClientParameters } from '@sinch/sdk-client';
 
 describe('Number Lookup API', () => {
   let numberLookupApi: NumberLookupDomainApi;
@@ -14,7 +14,7 @@ describe('Number Lookup API', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    lazyClient = new LazyNumberLookupApiClient(params);
+    lazyClient = new LazyNumberLookupApiClient(resolveClientParameters(params));
     errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 

--- a/packages/number-lookup/tests/rest/v2/number-lookup-domain.test.ts
+++ b/packages/number-lookup/tests/rest/v2/number-lookup-domain.test.ts
@@ -30,7 +30,7 @@ describe('Number Lookup API', () => {
   });
 
   it('should use the hostname parameter', () => {
-    params.numberLookupHostname = CUSTOM_HOSTNAME;
+    lazyClient.sharedConfig.numberLookupHostname = CUSTOM_HOSTNAME;
     numberLookupApi = new NumberLookupDomainApi(lazyClient, 'dummy');
     expect(numberLookupApi.client?.apiClientOptions.hostname).toBe(CUSTOM_HOSTNAME);
   });

--- a/packages/number-lookup/tests/rest/v2/number-lookup-domain.test.ts
+++ b/packages/number-lookup/tests/rest/v2/number-lookup-domain.test.ts
@@ -54,6 +54,7 @@ describe('Number Lookup API', () => {
     expect(() => numberLookupApi.setCredentials({ projectId: '' }))
       .toThrow('Invalid configuration for the Number Lookup API: "projectId", "keyId" and "keySecret"'
         + ' values must be provided');
-    expect(errorSpy).toHaveBeenCalledWith('Impossible to assign the new credentials to the Number Lookup API');
+    expect(errorSpy).toHaveBeenCalledWith('[Sinch SDK][Error] '
+      + 'Impossible to assign the new credentials to the Number Lookup API');
   });
 });

--- a/packages/number-lookup/tests/rest/v2/number-lookup-service.test.ts
+++ b/packages/number-lookup/tests/rest/v2/number-lookup-service.test.ts
@@ -137,7 +137,8 @@ describe('Number Lookup Service', () => {
     expect(() => numberLookupService.setCredentials({ projectId: '' }))
       .toThrow('Invalid configuration for the Number Lookup API: "projectId", "keyId" and "keySecret"'
         + ' values must be provided');
-    expect(errorSpy).toHaveBeenCalledWith('Impossible to assign the new credentials to the Number Lookup API');
+    expect(errorSpy).toHaveBeenCalledWith('[Sinch SDK][Error] '
+      + 'Impossible to assign the new credentials to the Number Lookup API');
 
     // Then
     expect((numberLookupService as any)._numberLookup.client.apiClientOptions.projectId).toBe('PROJECT_ID');

--- a/packages/number-lookup/tests/rest/v2/number-lookup/number-lookup-api.test.ts
+++ b/packages/number-lookup/tests/rest/v2/number-lookup/number-lookup-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import { LazyNumberLookupApiClient, NumberLookup } from '../../../../src';
 import { NumberLookupApi, NumberLookupApiFixture } from '../../../../src';
 
@@ -14,7 +14,7 @@ describe('NumberLookupApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyNumberLookupApiClient(credentials);
+    const lazyClient = new LazyNumberLookupApiClient(resolveClientParameters(credentials));
     numberLookupApi = new NumberLookupApi(lazyClient);
   });
 

--- a/packages/numbers/src/rest/v1/numbers-domain-api.ts
+++ b/packages/numbers/src/rest/v1/numbers-domain-api.ts
@@ -48,7 +48,7 @@ export class NumbersDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      this.lazyClient.sharedConfig.logger!.error(
+      this.lazyClient.sharedConfig.logger.error(
         'Impossible to assign the new credentials to the Numbers API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/numbers/src/rest/v1/numbers-domain-api.ts
+++ b/packages/numbers/src/rest/v1/numbers-domain-api.ts
@@ -1,6 +1,7 @@
 import {
   Api,
   ApiClient,
+  SinchLogger,
   UnifiedCredentials,
 } from '@sinch/sdk-client';
 import { LazyNumbersApiClient } from './numbers-service';
@@ -48,7 +49,9 @@ export class NumbersDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      console.error('Impossible to assign the new credentials to the Numbers API');
+      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+        'Impossible to assign the new credentials to the Numbers API',
+      );
       this.lazyClient.sharedConfig = parametersBackup;
       throw error;
     }

--- a/packages/numbers/src/rest/v1/numbers-domain-api.ts
+++ b/packages/numbers/src/rest/v1/numbers-domain-api.ts
@@ -1,9 +1,7 @@
 import {
   Api,
   ApiClient,
-  SinchLogger,
   UnifiedCredentials,
-  resolveLogger,
 } from '@sinch/sdk-client';
 import { LazyNumbersApiClient } from './numbers-service';
 
@@ -50,7 +48,7 @@ export class NumbersDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
+      this.lazyClient.sharedConfig.logger!.error(
         'Impossible to assign the new credentials to the Numbers API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/numbers/src/rest/v1/numbers-domain-api.ts
+++ b/packages/numbers/src/rest/v1/numbers-domain-api.ts
@@ -3,6 +3,7 @@ import {
   ApiClient,
   SinchLogger,
   UnifiedCredentials,
+  resolveLogger,
 } from '@sinch/sdk-client';
 import { LazyNumbersApiClient } from './numbers-service';
 
@@ -49,7 +50,7 @@ export class NumbersDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
         'Impossible to assign the new credentials to the Numbers API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/numbers/src/rest/v1/numbers-service.ts
+++ b/packages/numbers/src/rest/v1/numbers-service.ts
@@ -4,6 +4,7 @@ import {
   buildOAuth2ApiClientOptions,
   NUMBERS_HOSTNAME,
   SinchClientParameters,
+  SinchLogger,
   UnifiedCredentials,
 } from '@sinch/sdk-client';
 import { AvailableRegionsApi } from './available-regions';
@@ -110,7 +111,9 @@ export class NumbersService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      console.error('Impossible to assign the new credentials to the Numbers API');
+      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+        'Impossible to assign the new credentials to the Numbers API',
+      );
       this.lazyClient.sharedConfig = parametersBackup;
       throw error;
     }

--- a/packages/numbers/src/rest/v1/numbers-service.ts
+++ b/packages/numbers/src/rest/v1/numbers-service.ts
@@ -6,6 +6,7 @@ import {
   SinchClientParameters,
   SinchLogger,
   UnifiedCredentials,
+  resolveLogger,
 } from '@sinch/sdk-client';
 import { AvailableRegionsApi } from './available-regions';
 import { CallbacksApi } from './callbacks';
@@ -77,6 +78,7 @@ export class NumbersService {
    * @param {SinchClientParameters} params - an Object containing the necessary properties to initialize the service
    */
   constructor(params: SinchClientParameters) {
+    params.logger = resolveLogger(params.logger);
     const sharedClient = new LazyNumbersApiClient(params);
     this.lazyClient = sharedClient;
 
@@ -111,7 +113,7 @@ export class NumbersService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
         'Impossible to assign the new credentials to the Numbers API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/numbers/src/rest/v1/numbers-service.ts
+++ b/packages/numbers/src/rest/v1/numbers-service.ts
@@ -71,7 +71,8 @@ export class NumbersService {
    * @param {SinchClientParameters} params - an Object containing the necessary properties to initialize the service
    */
   constructor(params: SinchClientParameters) {
-    const sharedClient = new LazyNumbersApiClient(params);
+    const resolvedParams = resolveClientParameters(params);
+    const sharedClient = new LazyNumbersApiClient(resolvedParams);
     this.lazyClient = sharedClient;
 
     this.availableRegions = new AvailableRegionsApi(sharedClient);
@@ -81,7 +82,8 @@ export class NumbersService {
   }
 
   public setApiClientConfig(newParams: SinchClientParameters) {
-    this.lazyClient.sharedConfig = resolveClientParameters(newParams);
+    const resolvedParams = resolveClientParameters(newParams);
+    this.lazyClient.sharedConfig = resolvedParams;
     this.lazyClient.resetApiClient();
   }
 

--- a/packages/numbers/src/rest/v1/numbers-service.ts
+++ b/packages/numbers/src/rest/v1/numbers-service.ts
@@ -3,9 +3,10 @@ import {
   ApiListPromise,
   buildOAuth2ApiClientOptions,
   NUMBERS_HOSTNAME,
+  LazyApiClient,
   SinchClientParameters,
   UnifiedCredentials,
-  resolveLogger,
+  resolveClientParameters,
 } from '@sinch/sdk-client';
 import { AvailableRegionsApi } from './available-regions';
 import { CallbacksApi } from './callbacks';
@@ -31,10 +32,7 @@ import {
   ValidateEmergencyAddressRequestData,
 } from '../../models';
 
-export class LazyNumbersApiClient {
-  apiFetchClient?: ApiFetchClient;
-  constructor(public sharedConfig: SinchClientParameters) {}
-
+export class LazyNumbersApiClient extends LazyApiClient {
   public getApiClient(): ApiFetchClient {
     if (!this.apiFetchClient) {
       const apiClientOptions = buildOAuth2ApiClientOptions(this.sharedConfig, 'Numbers');
@@ -42,10 +40,6 @@ export class LazyNumbersApiClient {
       this.apiFetchClient.apiClientOptions.hostname = this.sharedConfig.numbersHostname ?? NUMBERS_HOSTNAME;
     }
     return this.apiFetchClient;
-  }
-
-  public resetApiClient() {
-    this.apiFetchClient = undefined;
   }
 }
 
@@ -77,7 +71,6 @@ export class NumbersService {
    * @param {SinchClientParameters} params - an Object containing the necessary properties to initialize the service
    */
   constructor(params: SinchClientParameters) {
-    params.logger = resolveLogger(params.logger);
     const sharedClient = new LazyNumbersApiClient(params);
     this.lazyClient = sharedClient;
 
@@ -88,7 +81,7 @@ export class NumbersService {
   }
 
   public setApiClientConfig(newParams: SinchClientParameters) {
-    this.lazyClient.sharedConfig = newParams;
+    this.lazyClient.sharedConfig = resolveClientParameters(newParams);
     this.lazyClient.resetApiClient();
   }
 
@@ -112,7 +105,7 @@ export class NumbersService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      this.lazyClient.sharedConfig.logger!.error(
+      this.lazyClient.sharedConfig.logger.error(
         'Impossible to assign the new credentials to the Numbers API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/numbers/src/rest/v1/numbers-service.ts
+++ b/packages/numbers/src/rest/v1/numbers-service.ts
@@ -4,7 +4,6 @@ import {
   buildOAuth2ApiClientOptions,
   NUMBERS_HOSTNAME,
   SinchClientParameters,
-  SinchLogger,
   UnifiedCredentials,
   resolveLogger,
 } from '@sinch/sdk-client';
@@ -113,7 +112,7 @@ export class NumbersService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
+      this.lazyClient.sharedConfig.logger!.error(
         'Impossible to assign the new credentials to the Numbers API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/numbers/tests/rest/v1/active-number/active-number-api.test.ts
+++ b/packages/numbers/tests/rest/v1/active-number/active-number-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   ActiveNumberApi,
   ActiveNumberApiFixture,
@@ -26,7 +26,7 @@ describe('ActiveNumberApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyNumbersApiClient(credentials);
+    const lazyClient = new LazyNumbersApiClient(resolveClientParameters(credentials));
     activeNumberApi = new ActiveNumberApi(lazyClient);
   });
 

--- a/packages/numbers/tests/rest/v1/available-number/available-number-api.test.ts
+++ b/packages/numbers/tests/rest/v1/available-number/available-number-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   AvailableNumberApi,
   AvailableNumberApiFixture,
@@ -18,7 +18,7 @@ describe('AvailableNumberApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyNumbersApiClient(credentials);
+    const lazyClient = new LazyNumbersApiClient(resolveClientParameters(credentials));
     availableNumberApi = new AvailableNumberApi(lazyClient);
   });
 

--- a/packages/numbers/tests/rest/v1/available-regions/available-regions-api.test.ts
+++ b/packages/numbers/tests/rest/v1/available-regions/available-regions-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   AvailableRegionsApi,
   AvailableRegionsApiFixture,
@@ -18,7 +18,7 @@ describe('AvailableRegionsApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyNumbersApiClient(credentials);
+    const lazyClient = new LazyNumbersApiClient(resolveClientParameters(credentials));
     availableRegionsApi = new AvailableRegionsApi(lazyClient);
   });
 

--- a/packages/numbers/tests/rest/v1/callbacks/callbacks-api.test.ts
+++ b/packages/numbers/tests/rest/v1/callbacks/callbacks-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   CallbacksApi,
   CallbackConfigurationApiFixture,
@@ -18,7 +18,7 @@ describe('CallbackConfigurationApi', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    const lazyClient = new LazyNumbersApiClient(credentials);
+    const lazyClient = new LazyNumbersApiClient(resolveClientParameters(credentials));
     callbacksApi = new CallbacksApi(lazyClient);
   });
 

--- a/packages/numbers/tests/rest/v1/numbers-api.test.ts
+++ b/packages/numbers/tests/rest/v1/numbers-api.test.ts
@@ -30,7 +30,7 @@ describe('Numbers API', () => {
   });
 
   it('should use the hostname parameter', () => {
-    params.numbersHostname = CUSTOM_HOSTNAME;
+    lazyClient.sharedConfig.numbersHostname = CUSTOM_HOSTNAME;
     numbersApi = new NumbersDomainApi(lazyClient, 'dummy');
     expect(numbersApi.client?.apiClientOptions.hostname).toBe(CUSTOM_HOSTNAME);
   });

--- a/packages/numbers/tests/rest/v1/numbers-api.test.ts
+++ b/packages/numbers/tests/rest/v1/numbers-api.test.ts
@@ -54,6 +54,7 @@ describe('Numbers API', () => {
     expect(() => numbersApi.setCredentials({ projectId: '' }))
       .toThrow('Invalid configuration for the Numbers API: "projectId", "keyId" and "keySecret"'
         + ' values must be provided');
-    expect(errorSpy).toHaveBeenCalledWith('Impossible to assign the new credentials to the Numbers API');
+    expect(errorSpy).toHaveBeenCalledWith('[Sinch SDK][Error] '
+      + 'Impossible to assign the new credentials to the Numbers API');
   });
 });

--- a/packages/numbers/tests/rest/v1/numbers-api.test.ts
+++ b/packages/numbers/tests/rest/v1/numbers-api.test.ts
@@ -1,5 +1,5 @@
 import { NumbersDomainApi, LazyNumbersApiClient } from '../../../src';
-import { ApiHostname, UnifiedCredentials } from '@sinch/sdk-client';
+import { ApiHostname, UnifiedCredentials, resolveClientParameters } from '@sinch/sdk-client';
 
 describe('Numbers API', () => {
   let numbersApi: NumbersDomainApi;
@@ -14,7 +14,7 @@ describe('Numbers API', () => {
       keyId: 'KEY_ID',
       keySecret: 'KEY_SECRET',
     };
-    lazyClient = new LazyNumbersApiClient(params);
+    lazyClient = new LazyNumbersApiClient(resolveClientParameters(params));
     errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 

--- a/packages/numbers/tests/rest/v1/numbers-service.test.ts
+++ b/packages/numbers/tests/rest/v1/numbers-service.test.ts
@@ -163,7 +163,8 @@ describe('Numbers Service', () => {
     expect(() => numbersService.setCredentials({ projectId: '' }))
       .toThrow('Invalid configuration for the Numbers API: "projectId", "keyId" and "keySecret"'
         + ' values must be provided');
-    expect(errorSpy).toHaveBeenCalledWith('Impossible to assign the new credentials to the Numbers API');
+    expect(errorSpy).toHaveBeenCalledWith('[Sinch SDK][Error] '
+      + 'Impossible to assign the new credentials to the Numbers API');
 
     // Then
     expect(numbersService.availableRegions.client.apiClientOptions.projectId).toBe('PROJECT_ID');

--- a/packages/sdk-client/CHANGELOG.md
+++ b/packages/sdk-client/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Version 1.5.0
+- [Feature] Add configurable SDK logging via the optional `logger` property on `SinchClientParameters` (`WithLogger`): provide a custom `Logger`, default to `console`, or pass `logger: null` to silence output; includes `SinchLogger` utilities, lazy message support, debug logging of failed HTTP responses, and routing of SDK warnings through the configured logger
+
 ## Version 1.4.2
 - [Bugfix] OAuth2 429 backoff with full-jitter retry
 

--- a/packages/sdk-client/CHANGELOG.md
+++ b/packages/sdk-client/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Version 1.5.0
-- [Feature] Add configurable SDK logging via the optional `logger` property on `SinchClientParameters` (`WithLogger`): provide a custom `Logger`, default to `console`, or pass `logger: null` to silence output; includes `SinchLogger` utilities, lazy message support, debug logging of failed HTTP responses, and routing of SDK warnings through the configured logger
+- [Feature] Add configurable SDK logging via the optional `logger` property on `SinchClientParameters` (`WithLogger`): provide a custom `Logger`, default to `console`, or pass `logger: null` to silence output; includes lazy message support, debug logging of failed HTTP responses, and routing of SDK warnings through the configured logger
 
 ## Version 1.4.2
 - [Bugfix] OAuth2 429 backoff with full-jitter retry

--- a/packages/sdk-client/src/api/api-client-options-helper.ts
+++ b/packages/sdk-client/src/api/api-client-options-helper.ts
@@ -8,7 +8,6 @@ import {
   XTimestampRequest,
 } from '../plugins';
 import { SinchLogger } from '../logger';
-import * as console from 'node:console';
 
 export const buildOAuth2ApiClientOptions = (params: SinchClientParameters, apiName: string): ApiClientOptions => {
   if (!params.projectId || !params.keyId || !params.keySecret) {

--- a/packages/sdk-client/src/api/api-client-options-helper.ts
+++ b/packages/sdk-client/src/api/api-client-options-helper.ts
@@ -15,10 +15,10 @@ export const buildOAuth2ApiClientOptions = (params: SinchClientParameters, apiNa
   const apiClientOptions: ApiClientOptions = {
     projectId: params.projectId,
     requestPlugins: [
-      new Oauth2TokenRequest(params.keyId, params.keySecret, params.authHostname, params.logHeadersOnError),
+      new Oauth2TokenRequest(params.keyId, params.keySecret, params.authHostname, params.logger),
     ],
     useServicePlanId: false,
-    logHeadersOnError: params.logHeadersOnError,
+    logger: params.logger,
   };
   addPlugins(apiClientOptions, params);
   return apiClientOptions;
@@ -48,7 +48,7 @@ export const buildApplicationSignedApiClientOptions = (
       new XTimestampRequest(),
       new SigningRequest(params.applicationKey, params.applicationSecret),
     ],
-    logHeadersOnError: params.logHeadersOnError,
+    logger: params.logger,
   };
   addPlugins(apiClientOptions, params);
   return apiClientOptions;
@@ -62,7 +62,7 @@ export const buildFlexibleOAuth2OrApiTokenApiClientOptions = (params: SinchClien
       projectId: params.servicePlanId,
       requestPlugins: [new ApiTokenRequest(params.apiToken)],
       useServicePlanId: true,
-      logHeadersOnError: params.logHeadersOnError,
+      logger: params.logger,
     };
     if (params.projectId || params.keyId || params.keySecret) {
       console.warn('As the servicePlanId and the apiToken are provided, all other credentials will be disregarded.');
@@ -71,10 +71,10 @@ export const buildFlexibleOAuth2OrApiTokenApiClientOptions = (params: SinchClien
     apiClientOptions = {
       projectId: params.projectId,
       requestPlugins: [
-        new Oauth2TokenRequest(params.keyId, params.keySecret, params.authHostname, params.logHeadersOnError),
+        new Oauth2TokenRequest(params.keyId, params.keySecret, params.authHostname, params.logger),
       ],
       useServicePlanId: false,
-      logHeadersOnError: params.logHeadersOnError,
+      logger: params.logger,
     };
   }
   if (!apiClientOptions) {

--- a/packages/sdk-client/src/api/api-client-options-helper.ts
+++ b/packages/sdk-client/src/api/api-client-options-helper.ts
@@ -7,7 +7,7 @@ import {
   SigningRequest,
   XTimestampRequest,
 } from '../plugins';
-import { SinchLogger, resolveLogger } from '../logger';
+import { resolveLogger } from '../logger';
 
 export const buildOAuth2ApiClientOptions = (params: SinchClientParameters, apiName: string): ApiClientOptions => {
   if (!params.projectId || !params.keyId || !params.keySecret) {
@@ -66,7 +66,7 @@ export const buildFlexibleOAuth2OrApiTokenApiClientOptions = (params: SinchClien
       logger: resolveLogger(params.logger),
     };
     if (params.projectId || params.keyId || params.keySecret) {
-      new SinchLogger(resolveLogger(params.logger)).warn(
+      resolveLogger(params.logger).warn(
         'As the servicePlanId and the apiToken are provided, all other credentials will be disregarded.');
     }
   } else if (params.projectId && params.keyId && params.keySecret) {

--- a/packages/sdk-client/src/api/api-client-options-helper.ts
+++ b/packages/sdk-client/src/api/api-client-options-helper.ts
@@ -9,17 +9,20 @@ import {
 } from '../plugins';
 import { resolveLogger } from '../logger';
 
+const resolveParamsLogger = (params: SinchClientParameters) => resolveLogger(params.logger);
+
 export const buildOAuth2ApiClientOptions = (params: SinchClientParameters, apiName: string): ApiClientOptions => {
   if (!params.projectId || !params.keyId || !params.keySecret) {
     throw new Error(`Invalid configuration for the ${apiName} API: "projectId", "keyId" and "keySecret" values must be provided`);
   }
+  const logger = resolveParamsLogger(params);
   const apiClientOptions: ApiClientOptions = {
     projectId: params.projectId,
     requestPlugins: [
-      new Oauth2TokenRequest(params.keyId, params.keySecret, params.authHostname, resolveLogger(params.logger)),
+      new Oauth2TokenRequest(params.keyId, params.keySecret, params.authHostname, logger),
     ],
     useServicePlanId: false,
-    logger: resolveLogger(params.logger),
+    logger,
   };
   addPlugins(apiClientOptions, params);
   return apiClientOptions;
@@ -29,10 +32,12 @@ export const buildMailgunApiClientOptions = (params: SinchClientParameters): Api
   if (!params.mailgunApiKey) {
     throw new Error('Invalid configuration for the Mailgun API: the "mailgunApiKey" must be provided');
   }
+  const logger = resolveParamsLogger(params);
   const apiClientOptions: ApiClientOptions = {
     requestPlugins: [
       new BasicAuthenticationRequest('api', params.mailgunApiKey),
     ],
+    logger,
   };
   addPlugins(apiClientOptions, params);
   return apiClientOptions;
@@ -44,18 +49,20 @@ export const buildApplicationSignedApiClientOptions = (
   if (!params.applicationKey || !params.applicationSecret) {
     throw new Error(`Invalid configuration for the ${apiName} API: "applicationKey" and "applicationSecret" values must be provided`);
   }
+  const logger = resolveParamsLogger(params);
   const apiClientOptions: ApiClientOptions = {
     requestPlugins: [
       new XTimestampRequest(),
       new SigningRequest(params.applicationKey, params.applicationSecret),
     ],
-    logger: resolveLogger(params.logger),
+    logger,
   };
   addPlugins(apiClientOptions, params);
   return apiClientOptions;
 };
 
 export const buildFlexibleOAuth2OrApiTokenApiClientOptions = (params: SinchClientParameters): ApiClientOptions => {
+  const logger = resolveParamsLogger(params);
   let apiClientOptions: ApiClientOptions | undefined;
 
   if (params.servicePlanId && params.apiToken) {
@@ -63,20 +70,20 @@ export const buildFlexibleOAuth2OrApiTokenApiClientOptions = (params: SinchClien
       projectId: params.servicePlanId,
       requestPlugins: [new ApiTokenRequest(params.apiToken)],
       useServicePlanId: true,
-      logger: resolveLogger(params.logger),
+      logger,
     };
     if (params.projectId || params.keyId || params.keySecret) {
-      resolveLogger(params.logger).warn(
+      logger.warn(
         'As the servicePlanId and the apiToken are provided, all other credentials will be disregarded.');
     }
   } else if (params.projectId && params.keyId && params.keySecret) {
     apiClientOptions = {
       projectId: params.projectId,
       requestPlugins: [
-        new Oauth2TokenRequest(params.keyId, params.keySecret, params.authHostname, resolveLogger(params.logger)),
+        new Oauth2TokenRequest(params.keyId, params.keySecret, params.authHostname, logger),
       ],
       useServicePlanId: false,
-      logger: resolveLogger(params.logger),
+      logger,
     };
   }
   if (!apiClientOptions) {

--- a/packages/sdk-client/src/api/api-client-options-helper.ts
+++ b/packages/sdk-client/src/api/api-client-options-helper.ts
@@ -7,7 +7,7 @@ import {
   SigningRequest,
   XTimestampRequest,
 } from '../plugins';
-import { SinchLogger } from '../logger';
+import { SinchLogger, resolveLogger } from '../logger';
 
 export const buildOAuth2ApiClientOptions = (params: SinchClientParameters, apiName: string): ApiClientOptions => {
   if (!params.projectId || !params.keyId || !params.keySecret) {
@@ -16,10 +16,10 @@ export const buildOAuth2ApiClientOptions = (params: SinchClientParameters, apiNa
   const apiClientOptions: ApiClientOptions = {
     projectId: params.projectId,
     requestPlugins: [
-      new Oauth2TokenRequest(params.keyId, params.keySecret, params.authHostname, params.logger),
+      new Oauth2TokenRequest(params.keyId, params.keySecret, params.authHostname, resolveLogger(params.logger)),
     ],
     useServicePlanId: false,
-    logger: params.logger,
+    logger: resolveLogger(params.logger),
   };
   addPlugins(apiClientOptions, params);
   return apiClientOptions;
@@ -49,7 +49,7 @@ export const buildApplicationSignedApiClientOptions = (
       new XTimestampRequest(),
       new SigningRequest(params.applicationKey, params.applicationSecret),
     ],
-    logger: params.logger,
+    logger: resolveLogger(params.logger),
   };
   addPlugins(apiClientOptions, params);
   return apiClientOptions;
@@ -63,20 +63,20 @@ export const buildFlexibleOAuth2OrApiTokenApiClientOptions = (params: SinchClien
       projectId: params.servicePlanId,
       requestPlugins: [new ApiTokenRequest(params.apiToken)],
       useServicePlanId: true,
-      logger: params.logger,
+      logger: resolveLogger(params.logger),
     };
     if (params.projectId || params.keyId || params.keySecret) {
-      new SinchLogger(params.logger ?? console).warn(
+      new SinchLogger(resolveLogger(params.logger)).warn(
         'As the servicePlanId and the apiToken are provided, all other credentials will be disregarded.');
     }
   } else if (params.projectId && params.keyId && params.keySecret) {
     apiClientOptions = {
       projectId: params.projectId,
       requestPlugins: [
-        new Oauth2TokenRequest(params.keyId, params.keySecret, params.authHostname, params.logger),
+        new Oauth2TokenRequest(params.keyId, params.keySecret, params.authHostname, resolveLogger(params.logger)),
       ],
       useServicePlanId: false,
-      logger: params.logger,
+      logger: resolveLogger(params.logger),
     };
   }
   if (!apiClientOptions) {

--- a/packages/sdk-client/src/api/api-client-options-helper.ts
+++ b/packages/sdk-client/src/api/api-client-options-helper.ts
@@ -14,8 +14,11 @@ export const buildOAuth2ApiClientOptions = (params: SinchClientParameters, apiNa
   }
   const apiClientOptions: ApiClientOptions = {
     projectId: params.projectId,
-    requestPlugins: [new Oauth2TokenRequest(params.keyId, params.keySecret, params.authHostname)],
+    requestPlugins: [
+      new Oauth2TokenRequest(params.keyId, params.keySecret, params.authHostname, params.logHeadersOnError),
+    ],
     useServicePlanId: false,
+    logHeadersOnError: params.logHeadersOnError,
   };
   addPlugins(apiClientOptions, params);
   return apiClientOptions;
@@ -45,6 +48,7 @@ export const buildApplicationSignedApiClientOptions = (
       new XTimestampRequest(),
       new SigningRequest(params.applicationKey, params.applicationSecret),
     ],
+    logHeadersOnError: params.logHeadersOnError,
   };
   addPlugins(apiClientOptions, params);
   return apiClientOptions;
@@ -58,6 +62,7 @@ export const buildFlexibleOAuth2OrApiTokenApiClientOptions = (params: SinchClien
       projectId: params.servicePlanId,
       requestPlugins: [new ApiTokenRequest(params.apiToken)],
       useServicePlanId: true,
+      logHeadersOnError: params.logHeadersOnError,
     };
     if (params.projectId || params.keyId || params.keySecret) {
       console.warn('As the servicePlanId and the apiToken are provided, all other credentials will be disregarded.');
@@ -65,8 +70,11 @@ export const buildFlexibleOAuth2OrApiTokenApiClientOptions = (params: SinchClien
   } else if (params.projectId && params.keyId && params.keySecret) {
     apiClientOptions = {
       projectId: params.projectId,
-      requestPlugins: [new Oauth2TokenRequest(params.keyId, params.keySecret, params.authHostname)],
+      requestPlugins: [
+        new Oauth2TokenRequest(params.keyId, params.keySecret, params.authHostname, params.logHeadersOnError),
+      ],
       useServicePlanId: false,
+      logHeadersOnError: params.logHeadersOnError,
     };
   }
   if (!apiClientOptions) {

--- a/packages/sdk-client/src/api/api-client-options-helper.ts
+++ b/packages/sdk-client/src/api/api-client-options-helper.ts
@@ -7,6 +7,8 @@ import {
   SigningRequest,
   XTimestampRequest,
 } from '../plugins';
+import { SinchLogger } from '../logger';
+import * as console from 'node:console';
 
 export const buildOAuth2ApiClientOptions = (params: SinchClientParameters, apiName: string): ApiClientOptions => {
   if (!params.projectId || !params.keyId || !params.keySecret) {
@@ -65,7 +67,8 @@ export const buildFlexibleOAuth2OrApiTokenApiClientOptions = (params: SinchClien
       logger: params.logger,
     };
     if (params.projectId || params.keyId || params.keySecret) {
-      console.warn('As the servicePlanId and the apiToken are provided, all other credentials will be disregarded.');
+      new SinchLogger(params.logger ?? console).warn(
+        'As the servicePlanId and the apiToken are provided, all other credentials will be disregarded.');
     }
   } else if (params.projectId && params.keyId && params.keySecret) {
     apiClientOptions = {

--- a/packages/sdk-client/src/api/api-client-options.ts
+++ b/packages/sdk-client/src/api/api-client-options.ts
@@ -1,6 +1,6 @@
 import { RequestPlugin } from '../plugins/core/request-plugin';
 import { ResponsePlugin } from '../plugins/core/response-plugin';
-import { DebugParameters } from '../domain';
+import { LoggerParameters } from '../domain';
 
 interface BaseApiClientOptions {
   /**
@@ -31,4 +31,4 @@ interface BaseApiClientOptions {
   useServicePlanId?: boolean;
 }
 
-export interface ApiClientOptions extends Partial<BaseApiClientOptions>, DebugParameters {}
+export interface ApiClientOptions extends Partial<BaseApiClientOptions>, LoggerParameters {}

--- a/packages/sdk-client/src/api/api-client-options.ts
+++ b/packages/sdk-client/src/api/api-client-options.ts
@@ -1,5 +1,6 @@
 import { RequestPlugin } from '../plugins/core/request-plugin';
 import { ResponsePlugin } from '../plugins/core/response-plugin';
+import { DebugParameters } from '../domain';
 
 interface BaseApiClientOptions {
   /**
@@ -30,4 +31,4 @@ interface BaseApiClientOptions {
   useServicePlanId?: boolean;
 }
 
-export interface ApiClientOptions extends Partial<BaseApiClientOptions> {}
+export interface ApiClientOptions extends Partial<BaseApiClientOptions>, DebugParameters {}

--- a/packages/sdk-client/src/api/api-client-options.ts
+++ b/packages/sdk-client/src/api/api-client-options.ts
@@ -1,6 +1,6 @@
 import { RequestPlugin } from '../plugins/core/request-plugin';
 import { ResponsePlugin } from '../plugins/core/response-plugin';
-import { LoggerParameters } from '../domain';
+import { WithLogger } from '../domain';
 
 interface BaseApiClientOptions {
   /**
@@ -31,4 +31,4 @@ interface BaseApiClientOptions {
   useServicePlanId?: boolean;
 }
 
-export interface ApiClientOptions extends Partial<BaseApiClientOptions>, LoggerParameters {}
+export interface ApiClientOptions extends Partial<BaseApiClientOptions>, WithLogger {}

--- a/packages/sdk-client/src/api/api-client.ts
+++ b/packages/sdk-client/src/api/api-client.ts
@@ -136,6 +136,7 @@ export class ApiClient {
         opts = await plugin.load().transform(opts);
       }
     }
+    opts.logHeadersOnError = this.apiClientOptions.logHeadersOnError;
 
     return opts;
   };

--- a/packages/sdk-client/src/api/api-client.ts
+++ b/packages/sdk-client/src/api/api-client.ts
@@ -136,7 +136,7 @@ export class ApiClient {
         opts = await plugin.load().transform(opts);
       }
     }
-    opts.logHeadersOnError = this.apiClientOptions.logHeadersOnError;
+    opts.logger = this.apiClientOptions.logger;
 
     return opts;
   };

--- a/packages/sdk-client/src/api/api-errors.ts
+++ b/packages/sdk-client/src/api/api-errors.ts
@@ -17,7 +17,7 @@ export class GenericError extends Error {
   constructor(message: string, errorContext: ErrorContext) {
     const baseUrl = GenericError.formatUrl(errorContext.url);
     super(
-      `[SDK] [apiName: ${errorContext.apiName || 'unknown'}]
+      `[apiName: ${errorContext.apiName || 'unknown'}]
         [operationId: ${errorContext.operationId || 'unknown'}] 
         [baseUrl: ${baseUrl}] [errorType: SDK] ${message}`,
     );

--- a/packages/sdk-client/src/client/api-fetch-client.ts
+++ b/packages/sdk-client/src/client/api-fetch-client.ts
@@ -20,7 +20,7 @@ import {
 } from '../api/api-errors';
 import fetch, { Response, Headers } from 'node-fetch';
 import { buildErrorContext, manageExpiredToken, reviveDates } from './api-client-helpers';
-import { SinchLogger, resolveLogger } from '../logger';
+import { resolveLogger } from '../logger';
 import {
   buildPaginationContext,
   calculateNextPage,
@@ -274,7 +274,7 @@ export class ApiFetchClient extends ApiClient {
   private logFailedResponse(context: ResponseContext): void {
     if (!context.response?.ok) {
       const { apiCallParameters } = context;
-      new SinchLogger(resolveLogger(this.apiClientOptions.logger)).debug(() =>
+      this.apiClientOptions.logger!.debug(() =>
         `[${apiCallParameters.apiName}][${apiCallParameters.operationId}][${context.response?.status}]\n`
         + `HTTP method: ${apiCallParameters.requestOptions.method}\n`
         + `URL: ${apiCallParameters.url}\n`

--- a/packages/sdk-client/src/client/api-fetch-client.ts
+++ b/packages/sdk-client/src/client/api-fetch-client.ts
@@ -61,7 +61,7 @@ export class ApiFetchClient extends ApiClient {
       ...options,
       requestPlugins: [new VersionRequest(), ...(options.requestPlugins || [])],
       responsePlugins: [
-        new ExceptionResponse(),
+        new ExceptionResponse(undefined, options.logger),
         ...(options.responsePlugins || []),
       ],
     });

--- a/packages/sdk-client/src/client/api-fetch-client.ts
+++ b/packages/sdk-client/src/client/api-fetch-client.ts
@@ -20,6 +20,7 @@ import {
 } from '../api/api-errors';
 import fetch, { Response, Headers } from 'node-fetch';
 import { buildErrorContext, manageExpiredToken, reviveDates } from './api-client-helpers';
+import { SinchLogger, resolveLogger } from '../logger';
 import {
   buildPaginationContext,
   calculateNextPage,
@@ -57,12 +58,16 @@ export class ApiFetchClient extends ApiClient {
    * @param {ApiClientOptions} options - Configuration options for the API Client.
    */
   constructor(options: ApiClientOptions) {
-    super({
+    const resolvedOptions = {
       ...options,
-      requestPlugins: [new VersionRequest(), ...(options.requestPlugins || [])],
+      logger: resolveLogger(options.logger),
+    };
+    super({
+      ...resolvedOptions,
+      requestPlugins: [new VersionRequest(), ...(resolvedOptions.requestPlugins || [])],
       responsePlugins: [
-        new ExceptionResponse(undefined, options.logger),
-        ...(options.responsePlugins || []),
+        new ExceptionResponse(undefined),
+        ...(resolvedOptions.responsePlugins || []),
       ],
     });
   }
@@ -118,6 +123,7 @@ export class ApiFetchClient extends ApiClient {
   private async processResponse<T>(
     context: ResponseContext,
   ): Promise<T> {
+    this.logFailedResponse(context);
     const pluginContext = await this.parseAndValidateResponse(context);
     const transformedResponse = await this.applyResponsePlugins(pluginContext);
 
@@ -263,6 +269,33 @@ export class ApiFetchClient extends ApiClient {
         nextPage,
       ),
     };
+  }
+
+  private logFailedResponse(context: ResponseContext): void {
+    if (!context.response?.ok) {
+      const { apiCallParameters } = context;
+      new SinchLogger(resolveLogger(this.apiClientOptions.logger)).debug(() =>
+        `[${apiCallParameters.apiName}][${apiCallParameters.operationId}][${context.response?.status}]\n`
+        + `HTTP method: ${apiCallParameters.requestOptions.method}\n`
+        + `URL: ${apiCallParameters.url}\n`
+        + `Response Headers: ${this.formatResponseHeaders(context.response?.headers)}`,
+      );
+    }
+  }
+
+  private formatResponseHeaders(headers: Headers | undefined): string {
+    if (!headers || typeof headers !== 'object') {
+      return '';
+    }
+
+    return Object.entries(Object.fromEntries(headers.entries()))
+      .map(([key, value]: [any, any]) => {
+        if (value === undefined) { return `${key}=undefined`; }
+        if (value === null) { return `${key}=null`; }
+        if (typeof value === 'object') { return `${key}=${JSON.stringify(value)}`; }
+        return `${key}=${String(value)}`;
+      })
+      .join(', ');
   }
 
   private buildFetchError(error: any, errorContext: ErrorContext): Error {

--- a/packages/sdk-client/src/client/api-fetch-client.ts
+++ b/packages/sdk-client/src/client/api-fetch-client.ts
@@ -21,6 +21,7 @@ import {
 import fetch, { Response, Headers } from 'node-fetch';
 import { buildErrorContext, manageExpiredToken, reviveDates } from './api-client-helpers';
 import { resolveLogger } from '../logger';
+import { isSinchLogger } from '../logger/sinch-logger';
 import {
   buildPaginationContext,
   calculateNextPage,
@@ -58,9 +59,12 @@ export class ApiFetchClient extends ApiClient {
    * @param {ApiClientOptions} options - Configuration options for the API Client.
    */
   constructor(options: ApiClientOptions) {
+    const logger = options.logger != null && isSinchLogger(options.logger)
+      ? options.logger
+      : resolveLogger(options.logger);
     const resolvedOptions = {
       ...options,
-      logger: resolveLogger(options.logger),
+      logger,
     };
     super({
       ...resolvedOptions,

--- a/packages/sdk-client/src/client/index.ts
+++ b/packages/sdk-client/src/client/index.ts
@@ -1,2 +1,3 @@
 export * from './api-fetch-client';
 export * from './api-client-pagination-helper';
+export * from './lazy-api-client';

--- a/packages/sdk-client/src/client/lazy-api-client.ts
+++ b/packages/sdk-client/src/client/lazy-api-client.ts
@@ -1,0 +1,17 @@
+import { ResolvedSinchClientParameters, SinchClientParameters } from '../domain';
+import { resolveClientParameters } from '../logger';
+import { ApiFetchClient } from './api-fetch-client';
+
+/** Base class for domain lazy clients that share resolved SDK configuration. */
+export abstract class LazyApiClient {
+  protected apiFetchClient?: ApiFetchClient;
+  public sharedConfig: ResolvedSinchClientParameters;
+
+  constructor(params: SinchClientParameters | ResolvedSinchClientParameters) {
+    this.sharedConfig = resolveClientParameters(params);
+  }
+
+  public resetApiClient(): void {
+    this.apiFetchClient = undefined;
+  }
+}

--- a/packages/sdk-client/src/client/lazy-api-client.ts
+++ b/packages/sdk-client/src/client/lazy-api-client.ts
@@ -1,5 +1,4 @@
-import { ResolvedSinchClientParameters, SinchClientParameters } from '../domain';
-import { resolveClientParameters } from '../logger';
+import { ResolvedSinchClientParameters } from '../domain';
 import { ApiFetchClient } from './api-fetch-client';
 
 /** Base class for domain lazy clients that share resolved SDK configuration. */
@@ -7,8 +6,8 @@ export abstract class LazyApiClient {
   public apiFetchClient?: ApiFetchClient;
   public sharedConfig: ResolvedSinchClientParameters;
 
-  constructor(params: SinchClientParameters | ResolvedSinchClientParameters) {
-    this.sharedConfig = resolveClientParameters(params);
+  constructor(sharedConfig: ResolvedSinchClientParameters) {
+    this.sharedConfig = sharedConfig;
   }
 
   public resetApiClient(): void {

--- a/packages/sdk-client/src/client/lazy-api-client.ts
+++ b/packages/sdk-client/src/client/lazy-api-client.ts
@@ -4,7 +4,7 @@ import { ApiFetchClient } from './api-fetch-client';
 
 /** Base class for domain lazy clients that share resolved SDK configuration. */
 export abstract class LazyApiClient {
-  protected apiFetchClient?: ApiFetchClient;
+  public apiFetchClient?: ApiFetchClient;
   public sharedConfig: ResolvedSinchClientParameters;
 
   constructor(params: SinchClientParameters | ResolvedSinchClientParameters) {

--- a/packages/sdk-client/src/domain/domain-interface.ts
+++ b/packages/sdk-client/src/domain/domain-interface.ts
@@ -197,3 +197,8 @@ export interface WithLogger {
    */
   logger?: Logger | null;
 }
+
+/** Sinch client parameters with a resolved logger (never null or undefined). */
+export type ResolvedSinchClientParameters = Omit<SinchClientParameters, 'logger'> & {
+  logger: Logger;
+};

--- a/packages/sdk-client/src/domain/domain-interface.ts
+++ b/packages/sdk-client/src/domain/domain-interface.ts
@@ -14,7 +14,8 @@ export type SinchClientParameters = Partial<
   & ServicePlanIdCredentials
   & ApplicationCredentials
   & ApiHostname
-  & ApiPlugins>;
+  & ApiPlugins
+  & DebugParameters>;
 
 export interface UnifiedCredentials {
   /** The project ID associated with the API Client. You can find this on your [Dashboard](https://dashboard.sinch.com/account/access-keys). */
@@ -186,3 +187,7 @@ export type MailgunRegion = SupportedMailgunRegion | string;
 export const MailgunRegion = {
   ...SupportedMailgunRegion,
 };
+
+export interface DebugParameters {
+  logHeadersOnError?: boolean;
+}

--- a/packages/sdk-client/src/domain/domain-interface.ts
+++ b/packages/sdk-client/src/domain/domain-interface.ts
@@ -1,5 +1,6 @@
 import { RequestPlugin } from '../plugins/core/request-plugin';
 import { ResponsePlugin } from '../plugins/core/response-plugin';
+import { Logger } from '../logger';
 
 /**
  * Global object that holds the API configuration.
@@ -15,7 +16,7 @@ export type SinchClientParameters = Partial<
   & ApplicationCredentials
   & ApiHostname
   & ApiPlugins
-  & DebugParameters>;
+  & LoggerParameters>;
 
 export interface UnifiedCredentials {
   /** The project ID associated with the API Client. You can find this on your [Dashboard](https://dashboard.sinch.com/account/access-keys). */
@@ -188,6 +189,7 @@ export const MailgunRegion = {
   ...SupportedMailgunRegion,
 };
 
-export interface DebugParameters {
-  logHeadersOnError?: boolean;
+export interface LoggerParameters {
+  /** Logger instance to be used by the SDK */
+  logger?: Logger;
 }

--- a/packages/sdk-client/src/domain/domain-interface.ts
+++ b/packages/sdk-client/src/domain/domain-interface.ts
@@ -16,7 +16,7 @@ export type SinchClientParameters = Partial<
   & ApplicationCredentials
   & ApiHostname
   & ApiPlugins
-  & LoggerParameters>;
+  & WithLogger>;
 
 export interface UnifiedCredentials {
   /** The project ID associated with the API Client. You can find this on your [Dashboard](https://dashboard.sinch.com/account/access-keys). */
@@ -189,7 +189,11 @@ export const MailgunRegion = {
   ...SupportedMailgunRegion,
 };
 
-export interface LoggerParameters {
-  /** Logger instance to be used by the SDK */
-  logger?: Logger;
+export interface WithLogger {
+  /**
+   * Logger instance to be used by the SDK.
+   * - omitted or `undefined`: defaults to `console`
+   * - `null`: silent (no SDK output)
+   */
+  logger?: Logger | null;
 }

--- a/packages/sdk-client/src/index.ts
+++ b/packages/sdk-client/src/index.ts
@@ -1,6 +1,7 @@
 export * from './api';
 export * from './client';
 export * from './domain';
+export * from './logger';
 export * from './model';
 export * from './plugins';
 export * from './utils';

--- a/packages/sdk-client/src/logger/index.ts
+++ b/packages/sdk-client/src/logger/index.ts
@@ -1,0 +1,1 @@
+export * from './logger';

--- a/packages/sdk-client/src/logger/index.ts
+++ b/packages/sdk-client/src/logger/index.ts
@@ -1,1 +1,7 @@
-export * from './logger';
+export type { LogMessage, Logger } from './logger-types';
+export {
+  CONSOLE_LOGGER,
+  NOOP_LOGGER,
+  resolveClientParameters,
+  resolveLogger,
+} from './logger';

--- a/packages/sdk-client/src/logger/logger-types.ts
+++ b/packages/sdk-client/src/logger/logger-types.ts
@@ -1,0 +1,8 @@
+export type LogMessage = string | (() => string);
+
+export interface Logger {
+  debug(message: LogMessage, ...meta: any[]): void;
+  info(message: LogMessage, ...meta: any[]): void;
+  warn(message: LogMessage, ...meta: any[]): void;
+  error(message: LogMessage, ...meta: any[]): void;
+}

--- a/packages/sdk-client/src/logger/logger.ts
+++ b/packages/sdk-client/src/logger/logger.ts
@@ -4,3 +4,24 @@ export interface Logger {
   warn(message: string, ...meta: any[]): void;
   error(message: string, ...meta: any[]): void;
 }
+
+export class SinchLogger implements Logger {
+  constructor(private baseLogger: Logger) {}
+
+  private format(level: string, message: string): string {
+    return `[Sinch SDK][${level}] ${message}`;
+  }
+
+  debug(message: string, ...meta: any[]): void {
+    this.baseLogger.debug(this.format('Debug', message), ...meta);
+  }
+  info(message: string, ...meta: any[]): void {
+    this.baseLogger.info(this.format('Info', message), ...meta);
+  }
+  warn(message: string, ...meta: any[]): void {
+    this.baseLogger.warn(this.format('Warn', message), ...meta);
+  }
+  error(message: string, ...meta: any[]): void {
+    this.baseLogger.error(this.format('Error', message), ...meta);
+  }
+}

--- a/packages/sdk-client/src/logger/logger.ts
+++ b/packages/sdk-client/src/logger/logger.ts
@@ -1,0 +1,6 @@
+export interface Logger {
+  debug(message: string, ...meta: any[]): void;
+  info(message: string, ...meta: any[]): void;
+  warn(message: string, ...meta: any[]): void;
+  error(message: string, ...meta: any[]): void;
+}

--- a/packages/sdk-client/src/logger/logger.ts
+++ b/packages/sdk-client/src/logger/logger.ts
@@ -1,3 +1,5 @@
+import type { ResolvedSinchClientParameters, SinchClientParameters } from '../domain';
+
 export type LogMessage = string | (() => string);
 
 export interface Logger {
@@ -39,6 +41,18 @@ export const resolveLogger = (logger?: Logger | null): Logger => {
     return logger;
   }
   return new SinchLogger(resolveBaseLogger(logger));
+};
+
+export const resolveClientParameters = (
+  params: SinchClientParameters | ResolvedSinchClientParameters,
+): ResolvedSinchClientParameters => {
+  if (params.logger instanceof SinchLogger) {
+    return params as ResolvedSinchClientParameters;
+  }
+  return {
+    ...params,
+    logger: resolveLogger(params.logger),
+  };
 };
 
 export class SinchLogger implements Logger {

--- a/packages/sdk-client/src/logger/logger.ts
+++ b/packages/sdk-client/src/logger/logger.ts
@@ -1,9 +1,38 @@
+export type LogMessage = string | (() => string);
+
 export interface Logger {
-  debug(message: string, ...meta: any[]): void;
-  info(message: string, ...meta: any[]): void;
-  warn(message: string, ...meta: any[]): void;
-  error(message: string, ...meta: any[]): void;
+  debug(message: LogMessage, ...meta: any[]): void;
+  info(message: LogMessage, ...meta: any[]): void;
+  warn(message: LogMessage, ...meta: any[]): void;
+  error(message: LogMessage, ...meta: any[]): void;
 }
+
+const evaluateMessage = (message: LogMessage): string =>
+  typeof message === 'function' ? message() : message;
+
+export const CONSOLE_LOGGER: Logger = {
+  debug: (message, ...meta) => console.debug(evaluateMessage(message), ...meta),
+  info: (message, ...meta) => console.info(evaluateMessage(message), ...meta),
+  warn: (message, ...meta) => console.warn(evaluateMessage(message), ...meta),
+  error: (message, ...meta) => console.error(evaluateMessage(message), ...meta),
+};
+
+export const NOOP_LOGGER: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+export const resolveLogger = (logger?: Logger | null): Logger => {
+  if (logger === null) {
+    return NOOP_LOGGER;
+  }
+  if (logger === undefined) {
+    return CONSOLE_LOGGER;
+  }
+  return logger;
+};
 
 export class SinchLogger implements Logger {
   constructor(private baseLogger: Logger) {}
@@ -12,16 +41,24 @@ export class SinchLogger implements Logger {
     return `[Sinch SDK][${level}] ${message}`;
   }
 
-  debug(message: string, ...meta: any[]): void {
-    this.baseLogger.debug(this.format('Debug', message), ...meta);
+  private log(level: string, method: keyof Logger, message: LogMessage, ...meta: any[]): void {
+    if (typeof message === 'function') {
+      this.baseLogger[method](() => this.format(level, message()), ...meta);
+    } else {
+      this.baseLogger[method](this.format(level, message), ...meta);
+    }
   }
-  info(message: string, ...meta: any[]): void {
-    this.baseLogger.info(this.format('Info', message), ...meta);
+
+  debug(message: LogMessage, ...meta: any[]): void {
+    this.log('Debug', 'debug', message, ...meta);
   }
-  warn(message: string, ...meta: any[]): void {
-    this.baseLogger.warn(this.format('Warn', message), ...meta);
+  info(message: LogMessage, ...meta: any[]): void {
+    this.log('Info', 'info', message, ...meta);
   }
-  error(message: string, ...meta: any[]): void {
-    this.baseLogger.error(this.format('Error', message), ...meta);
+  warn(message: LogMessage, ...meta: any[]): void {
+    this.log('Warn', 'warn', message, ...meta);
+  }
+  error(message: LogMessage, ...meta: any[]): void {
+    this.log('Error', 'error', message, ...meta);
   }
 }

--- a/packages/sdk-client/src/logger/logger.ts
+++ b/packages/sdk-client/src/logger/logger.ts
@@ -1,13 +1,8 @@
 import type { ResolvedSinchClientParameters, SinchClientParameters } from '../domain';
+import type { Logger, LogMessage } from './logger-types';
+import { isSinchLogger, SinchLogger } from './sinch-logger';
 
-export type LogMessage = string | (() => string);
-
-export interface Logger {
-  debug(message: LogMessage, ...meta: any[]): void;
-  info(message: LogMessage, ...meta: any[]): void;
-  warn(message: LogMessage, ...meta: any[]): void;
-  error(message: LogMessage, ...meta: any[]): void;
-}
+export type { LogMessage, Logger } from './logger-types';
 
 const evaluateMessage = (message: LogMessage): string =>
   typeof message === 'function' ? message() : message;
@@ -37,7 +32,7 @@ const resolveBaseLogger = (logger?: Logger | null): Logger => {
 };
 
 export const resolveLogger = (logger?: Logger | null): Logger => {
-  if (logger instanceof SinchLogger) {
+  if (logger != null && isSinchLogger(logger)) {
     return logger;
   }
   return new SinchLogger(resolveBaseLogger(logger));
@@ -46,7 +41,7 @@ export const resolveLogger = (logger?: Logger | null): Logger => {
 export const resolveClientParameters = (
   params: SinchClientParameters | ResolvedSinchClientParameters,
 ): ResolvedSinchClientParameters => {
-  if (params.logger instanceof SinchLogger) {
+  if (params.logger != null && isSinchLogger(params.logger)) {
     return params as ResolvedSinchClientParameters;
   }
   return {
@@ -54,32 +49,3 @@ export const resolveClientParameters = (
     logger: resolveLogger(params.logger),
   };
 };
-
-export class SinchLogger implements Logger {
-  constructor(private baseLogger: Logger) {}
-
-  private format(level: string, message: string): string {
-    return `[Sinch SDK][${level}] ${message}`;
-  }
-
-  private log(level: string, method: keyof Logger, message: LogMessage, ...meta: any[]): void {
-    if (typeof message === 'function') {
-      this.baseLogger[method](() => this.format(level, message()), ...meta);
-    } else {
-      this.baseLogger[method](this.format(level, message), ...meta);
-    }
-  }
-
-  debug(message: LogMessage, ...meta: any[]): void {
-    this.log('Debug', 'debug', message, ...meta);
-  }
-  info(message: LogMessage, ...meta: any[]): void {
-    this.log('Info', 'info', message, ...meta);
-  }
-  warn(message: LogMessage, ...meta: any[]): void {
-    this.log('Warn', 'warn', message, ...meta);
-  }
-  error(message: LogMessage, ...meta: any[]): void {
-    this.log('Error', 'error', message, ...meta);
-  }
-}

--- a/packages/sdk-client/src/logger/logger.ts
+++ b/packages/sdk-client/src/logger/logger.ts
@@ -24,7 +24,7 @@ export const NOOP_LOGGER: Logger = {
   error: () => {},
 };
 
-export const resolveLogger = (logger?: Logger | null): Logger => {
+const resolveBaseLogger = (logger?: Logger | null): Logger => {
   if (logger === null) {
     return NOOP_LOGGER;
   }
@@ -32,6 +32,13 @@ export const resolveLogger = (logger?: Logger | null): Logger => {
     return CONSOLE_LOGGER;
   }
   return logger;
+};
+
+export const resolveLogger = (logger?: Logger | null): Logger => {
+  if (logger instanceof SinchLogger) {
+    return logger;
+  }
+  return new SinchLogger(resolveBaseLogger(logger));
 };
 
 export class SinchLogger implements Logger {

--- a/packages/sdk-client/src/logger/sinch-logger.ts
+++ b/packages/sdk-client/src/logger/sinch-logger.ts
@@ -1,0 +1,36 @@
+import type { Logger, LogMessage } from './logger-types';
+
+const sinchLoggers = new WeakSet<Logger>();
+
+export const isSinchLogger = (logger: Logger): boolean => sinchLoggers.has(logger);
+
+export class SinchLogger implements Logger {
+  constructor(private baseLogger: Logger) {
+    sinchLoggers.add(this);
+  }
+
+  private format(level: string, message: string): string {
+    return `[Sinch SDK][${level}] ${message}`;
+  }
+
+  private log(level: string, method: keyof Logger, message: LogMessage, ...meta: any[]): void {
+    if (typeof message === 'function') {
+      this.baseLogger[method](() => this.format(level, message()), ...meta);
+    } else {
+      this.baseLogger[method](this.format(level, message), ...meta);
+    }
+  }
+
+  debug(message: LogMessage, ...meta: any[]): void {
+    this.log('Debug', 'debug', message, ...meta);
+  }
+  info(message: LogMessage, ...meta: any[]): void {
+    this.log('Info', 'info', message, ...meta);
+  }
+  warn(message: LogMessage, ...meta: any[]): void {
+    this.log('Warn', 'warn', message, ...meta);
+  }
+  error(message: LogMessage, ...meta: any[]): void {
+    this.log('Error', 'error', message, ...meta);
+  }
+}

--- a/packages/sdk-client/src/plugins/core/request-plugin.ts
+++ b/packages/sdk-client/src/plugins/core/request-plugin.ts
@@ -1,7 +1,7 @@
 import { Plugin, PluginRunner } from './plugin';
 import { Headers, RequestInit } from 'node-fetch';
 import FormData = require('form-data');
-import { DebugParameters } from '../../domain';
+import { LoggerParameters } from '../../domain';
 
 export type RequestBody = string | FormData;
 
@@ -15,7 +15,7 @@ export enum RequestPluginEnum {
   X_TIMESTAMP_REQUEST = 'XTimestampRequest'
 }
 
-export interface RequestOptions extends RequestInit, DebugParameters {
+export interface RequestOptions extends RequestInit, LoggerParameters {
   /** Query Parameters */
   queryParams?: { [key: string]: string };
   /** Force body to string */

--- a/packages/sdk-client/src/plugins/core/request-plugin.ts
+++ b/packages/sdk-client/src/plugins/core/request-plugin.ts
@@ -1,6 +1,7 @@
 import { Plugin, PluginRunner } from './plugin';
 import { Headers, RequestInit } from 'node-fetch';
 import FormData = require('form-data');
+import { DebugParameters } from '../../domain';
 
 export type RequestBody = string | FormData;
 
@@ -14,7 +15,7 @@ export enum RequestPluginEnum {
   X_TIMESTAMP_REQUEST = 'XTimestampRequest'
 }
 
-export interface RequestOptions extends RequestInit {
+export interface RequestOptions extends RequestInit, DebugParameters {
   /** Query Parameters */
   queryParams?: { [key: string]: string };
   /** Force body to string */

--- a/packages/sdk-client/src/plugins/core/request-plugin.ts
+++ b/packages/sdk-client/src/plugins/core/request-plugin.ts
@@ -1,7 +1,7 @@
 import { Plugin, PluginRunner } from './plugin';
 import { Headers, RequestInit } from 'node-fetch';
 import FormData = require('form-data');
-import { LoggerParameters } from '../../domain';
+import { WithLogger } from '../../domain';
 
 export type RequestBody = string | FormData;
 
@@ -15,7 +15,7 @@ export enum RequestPluginEnum {
   X_TIMESTAMP_REQUEST = 'XTimestampRequest'
 }
 
-export interface RequestOptions extends RequestInit, LoggerParameters {
+export interface RequestOptions extends RequestInit, WithLogger {
   /** Query Parameters */
   queryParams?: { [key: string]: string };
   /** Force body to string */

--- a/packages/sdk-client/src/plugins/exception/exception.response.ts
+++ b/packages/sdk-client/src/plugins/exception/exception.response.ts
@@ -1,6 +1,7 @@
 import { EmptyResponseError, RequestFailedError } from '../../api/api-errors';
 import { PluginRunner } from '../core';
 import { ResponsePlugin, ResponsePluginContext } from '../core/response-plugin';
+import { Logger } from '../../logger';
 
 /**
  * Plugin to fire an exception on wrong response / data
@@ -13,8 +14,12 @@ export class ExceptionResponse<
  * Initialize an instance of the class, with an optional callback function for exception handling.
  *
  * @param {Function} [callback] - A function called in case of an exception. If provided, this function is responsible for throwing the exception or not.
+ * @param {Logger} logger
  */
-  constructor(private callback?: (res: V, error: Error | undefined) => V) {}
+  constructor(
+    private callback?: (res: V, error: Error | undefined) => V,
+    private logger: Logger = console,
+  ) {}
 
   public load(
     context: ResponsePluginContext,
@@ -75,11 +80,25 @@ export class ExceptionResponse<
   }
 
   private debug(context: ResponsePluginContext) {
-    if (context.requestOptions.logHeadersOnError && !context.response?.ok) {
-      console.debug(
-        `[Sinch SDK][Debug][${context.apiName}][${context.operationId}][${context.response?.status}]\nHTTP method: ${context.requestOptions.method}\nURL: ${context.url}\nResponse Headers: `,
-        context.response?.headers,
+    if (!context.response?.ok) {
+      this.logger.debug(
+        `[Sinch SDK][Debug][${context.apiName}][${context.operationId}][${context.response?.status}]\nHTTP method: ${context.requestOptions.method}\nURL: ${context.url}\nResponse Headers: ${this.formatHeaders(context.response?.headers)}`,
       );
     }
+  }
+
+  private formatHeaders(headers: any) {
+    if (!headers || typeof headers !== 'object') {
+      return '';
+    }
+
+    return Object.entries(Object.fromEntries(headers.entries()))
+      .map(([key, value]: [any, any]) => {
+        if (value === undefined) { return `${key}=undefined`; }
+        if (value === null) { return `${key}=null`; }
+        if (typeof value === 'object') { return `${key}=${JSON.stringify(value)}`; }
+        return `${key}=${String(value)}`;
+      })
+      .join(', ');
   }
 }

--- a/packages/sdk-client/src/plugins/exception/exception.response.ts
+++ b/packages/sdk-client/src/plugins/exception/exception.response.ts
@@ -1,7 +1,7 @@
 import { EmptyResponseError, RequestFailedError } from '../../api/api-errors';
 import { PluginRunner } from '../core';
 import { ResponsePlugin, ResponsePluginContext } from '../core/response-plugin';
-import { Logger } from '../../logger';
+import { Logger, SinchLogger } from '../../logger';
 
 /**
  * Plugin to fire an exception on wrong response / data
@@ -10,7 +10,9 @@ export class ExceptionResponse<
   V extends Record<string, any> | undefined = Record<string, any>,
 > implements ResponsePlugin<V | Record<string, unknown>, V>
 {
-/**
+  private logger: SinchLogger;
+
+  /**
  * Initialize an instance of the class, with an optional callback function for exception handling.
  *
  * @param {Function} [callback] - A function called in case of an exception. If provided, this function is responsible for throwing the exception or not.
@@ -18,8 +20,10 @@ export class ExceptionResponse<
  */
   constructor(
     private callback?: (res: V, error: Error | undefined) => V,
-    private logger: Logger = console,
-  ) {}
+    logger: Logger = console,
+  ) {
+    this.logger = new SinchLogger(logger);
+  }
 
   public load(
     context: ResponsePluginContext,
@@ -82,7 +86,7 @@ export class ExceptionResponse<
   private debug(context: ResponsePluginContext) {
     if (!context.response?.ok) {
       this.logger.debug(
-        `[Sinch SDK][Debug][${context.apiName}][${context.operationId}][${context.response?.status}]\nHTTP method: ${context.requestOptions.method}\nURL: ${context.url}\nResponse Headers: ${this.formatHeaders(context.response?.headers)}`,
+        `[${context.apiName}][${context.operationId}][${context.response?.status}]\nHTTP method: ${context.requestOptions.method}\nURL: ${context.url}\nResponse Headers: ${this.formatHeaders(context.response?.headers)}`,
       );
     }
   }

--- a/packages/sdk-client/src/plugins/exception/exception.response.ts
+++ b/packages/sdk-client/src/plugins/exception/exception.response.ts
@@ -21,6 +21,7 @@ export class ExceptionResponse<
   ): PluginRunner<V | Record<string, unknown>, V> {
     return {
       transform: (res: V) => {
+        this.debug(context);
         if (context.exception) {
           return res;
         }
@@ -71,5 +72,14 @@ export class ExceptionResponse<
         return res;
       },
     };
+  }
+
+  private debug(context: ResponsePluginContext) {
+    if (context.requestOptions.logHeadersOnError && !context.response?.ok) {
+      console.debug(
+        `[Sinch SDK][Debug][${context.apiName}][${context.operationId}][${context.response?.status}]\nHTTP method: ${context.requestOptions.method}\nURL: ${context.url}\nResponse Headers: `,
+        context.response?.headers,
+      );
+    }
   }
 }

--- a/packages/sdk-client/src/plugins/exception/exception.response.ts
+++ b/packages/sdk-client/src/plugins/exception/exception.response.ts
@@ -1,7 +1,6 @@
 import { EmptyResponseError, RequestFailedError } from '../../api/api-errors';
 import { PluginRunner } from '../core';
 import { ResponsePlugin, ResponsePluginContext } from '../core/response-plugin';
-import { Logger, SinchLogger } from '../../logger';
 
 /**
  * Plugin to fire an exception on wrong response / data
@@ -10,27 +9,20 @@ export class ExceptionResponse<
   V extends Record<string, any> | undefined = Record<string, any>,
 > implements ResponsePlugin<V | Record<string, unknown>, V>
 {
-  private logger: SinchLogger;
-
   /**
  * Initialize an instance of the class, with an optional callback function for exception handling.
  *
  * @param {Function} [callback] - A function called in case of an exception. If provided, this function is responsible for throwing the exception or not.
- * @param {Logger} logger
  */
   constructor(
     private callback?: (res: V, error: Error | undefined) => V,
-    logger: Logger = console,
-  ) {
-    this.logger = new SinchLogger(logger);
-  }
+  ) {}
 
   public load(
     context: ResponsePluginContext,
   ): PluginRunner<V | Record<string, unknown>, V> {
     return {
       transform: (res: V) => {
-        this.debug(context);
         if (context.exception) {
           return res;
         }
@@ -81,28 +73,5 @@ export class ExceptionResponse<
         return res;
       },
     };
-  }
-
-  private debug(context: ResponsePluginContext) {
-    if (!context.response?.ok) {
-      this.logger.debug(
-        `[${context.apiName}][${context.operationId}][${context.response?.status}]\nHTTP method: ${context.requestOptions.method}\nURL: ${context.url}\nResponse Headers: ${this.formatHeaders(context.response?.headers)}`,
-      );
-    }
-  }
-
-  private formatHeaders(headers: any) {
-    if (!headers || typeof headers !== 'object') {
-      return '';
-    }
-
-    return Object.entries(Object.fromEntries(headers.entries()))
-      .map(([key, value]: [any, any]) => {
-        if (value === undefined) { return `${key}=undefined`; }
-        if (value === null) { return `${key}=null`; }
-        if (typeof value === 'object') { return `${key}=${JSON.stringify(value)}`; }
-        return `${key}=${String(value)}`;
-      })
-      .join(', ');
   }
 }

--- a/packages/sdk-client/src/plugins/oauth2/oauth2-token.request.ts
+++ b/packages/sdk-client/src/plugins/oauth2/oauth2-token.request.ts
@@ -41,6 +41,7 @@ export class Oauth2TokenRequest implements RequestPlugin {
     clientId: string,
     clientSecret: string,
     authenticationUrl?: string,
+    logHeadersOnError?: boolean,
   ) {
     const basicAuthenticationPlugin = new BasicAuthenticationRequest(
       clientId,
@@ -52,6 +53,7 @@ export class Oauth2TokenRequest implements RequestPlugin {
     this.apiClient = new ApiFetchClient({
       hostname: authenticationUrl,
       requestPlugins: [basicAuthenticationPlugin],
+      logHeadersOnError: logHeadersOnError,
     });
   }
 

--- a/packages/sdk-client/src/plugins/oauth2/oauth2-token.request.ts
+++ b/packages/sdk-client/src/plugins/oauth2/oauth2-token.request.ts
@@ -7,6 +7,7 @@ import { BasicAuthenticationRequest } from '../basicAuthentication';
 import { ApiFetchClient } from '../../client/api-fetch-client';
 import { AUTH_HOSTNAME } from '../../domain';
 import { RequestFailedError } from '../../api/api-errors';
+import { Logger } from '../../logger';
 
 const EXPIRY_SAFETY_MARGIN_SEC = 60;
 
@@ -41,7 +42,7 @@ export class Oauth2TokenRequest implements RequestPlugin {
     clientId: string,
     clientSecret: string,
     authenticationUrl?: string,
-    logHeadersOnError?: boolean,
+    logger?: Logger,
   ) {
     const basicAuthenticationPlugin = new BasicAuthenticationRequest(
       clientId,
@@ -53,7 +54,7 @@ export class Oauth2TokenRequest implements RequestPlugin {
     this.apiClient = new ApiFetchClient({
       hostname: authenticationUrl,
       requestPlugins: [basicAuthenticationPlugin],
-      logHeadersOnError: logHeadersOnError,
+      logger,
     });
   }
 

--- a/packages/sdk-client/src/plugins/oauth2/oauth2-token.request.ts
+++ b/packages/sdk-client/src/plugins/oauth2/oauth2-token.request.ts
@@ -7,7 +7,7 @@ import { BasicAuthenticationRequest } from '../basicAuthentication';
 import { ApiFetchClient } from '../../client/api-fetch-client';
 import { AUTH_HOSTNAME } from '../../domain';
 import { RequestFailedError } from '../../api/api-errors';
-import { Logger } from '../../logger';
+import { Logger, SinchLogger } from '../../logger';
 
 const EXPIRY_SAFETY_MARGIN_SEC = 60;
 
@@ -30,6 +30,7 @@ export class Oauth2TokenRequest implements RequestPlugin {
   private readonly apiClient: ApiClient;
 
   private token: AccessToken | undefined;
+  private logger: Logger;
 
   /** Shared promise for concurrent token refresh */
   private pendingTokenRefresh: Promise<{ [key: string]: string }> | null = null;
@@ -51,6 +52,7 @@ export class Oauth2TokenRequest implements RequestPlugin {
     if (!authenticationUrl) {
       authenticationUrl = AUTH_HOSTNAME;
     }
+    this.logger = new SinchLogger(logger ?? console);
     this.apiClient = new ApiFetchClient({
       hostname: authenticationUrl,
       requestPlugins: [basicAuthenticationPlugin],

--- a/packages/sdk-client/src/plugins/oauth2/oauth2-token.request.ts
+++ b/packages/sdk-client/src/plugins/oauth2/oauth2-token.request.ts
@@ -42,7 +42,7 @@ export class Oauth2TokenRequest implements RequestPlugin {
     clientId: string,
     clientSecret: string,
     authenticationUrl?: string,
-    logger?: Logger,
+    logger?: Logger | null,
   ) {
     const basicAuthenticationPlugin = new BasicAuthenticationRequest(
       clientId,

--- a/packages/sdk-client/src/plugins/oauth2/oauth2-token.request.ts
+++ b/packages/sdk-client/src/plugins/oauth2/oauth2-token.request.ts
@@ -7,7 +7,7 @@ import { BasicAuthenticationRequest } from '../basicAuthentication';
 import { ApiFetchClient } from '../../client/api-fetch-client';
 import { AUTH_HOSTNAME } from '../../domain';
 import { RequestFailedError } from '../../api/api-errors';
-import { Logger, SinchLogger } from '../../logger';
+import { Logger } from '../../logger';
 
 const EXPIRY_SAFETY_MARGIN_SEC = 60;
 
@@ -30,7 +30,6 @@ export class Oauth2TokenRequest implements RequestPlugin {
   private readonly apiClient: ApiClient;
 
   private token: AccessToken | undefined;
-  private logger: Logger;
 
   /** Shared promise for concurrent token refresh */
   private pendingTokenRefresh: Promise<{ [key: string]: string }> | null = null;
@@ -52,7 +51,6 @@ export class Oauth2TokenRequest implements RequestPlugin {
     if (!authenticationUrl) {
       authenticationUrl = AUTH_HOSTNAME;
     }
-    this.logger = new SinchLogger(logger ?? console);
     this.apiClient = new ApiFetchClient({
       hostname: authenticationUrl,
       requestPlugins: [basicAuthenticationPlugin],

--- a/packages/sdk-client/src/utils/authorization.helper.ts
+++ b/packages/sdk-client/src/utils/authorization.helper.ts
@@ -1,8 +1,7 @@
 import crypto from 'crypto';
 import { IncomingHttpHeaders } from 'http';
 import { RequestBody } from '../plugins/core/request-plugin';
-import * as console from 'console';
-import { Logger, SinchLogger } from '../logger';
+import { Logger, SinchLogger, resolveLogger } from '../logger';
 
 /**
  * Generate authorization header for application-signed requests (Verification and Voice)
@@ -84,9 +83,9 @@ export const validateAuthenticationHeader = (
   body: any,
   path: string,
   method: string,
-  logger? : Logger,
+  logger? : Logger | null,
 ): boolean => {
-  const sinchLogger = new SinchLogger(logger ?? console);
+  const sinchLogger = new SinchLogger(resolveLogger(logger));
   const normalizedHeaders = normalizeHeaders(headers);
 
   const authorization = getHeader(normalizedHeaders.authorization);

--- a/packages/sdk-client/src/utils/authorization.helper.ts
+++ b/packages/sdk-client/src/utils/authorization.helper.ts
@@ -1,6 +1,8 @@
 import crypto from 'crypto';
 import { IncomingHttpHeaders } from 'http';
 import { RequestBody } from '../plugins/core/request-plugin';
+import * as console from 'console';
+import { Logger, SinchLogger } from '../logger';
 
 /**
  * Generate authorization header for application-signed requests (Verification and Voice)
@@ -72,6 +74,7 @@ export const validateWebhookSignature = (
  * @param {any} body - Incoming request's body
  * @param {string} path - Incoming request's path
  * @param {string} method - Incoming request's HTTP method
+ * @param {Logger} logger
  * @return {boolean} - true if the authorization header is valid
  */
 export const validateAuthenticationHeader = (
@@ -81,14 +84,16 @@ export const validateAuthenticationHeader = (
   body: any,
   path: string,
   method: string,
+  logger? : Logger,
 ): boolean => {
+  const sinchLogger = new SinchLogger(logger ?? console);
   const normalizedHeaders = normalizeHeaders(headers);
 
   const authorization = getHeader(normalizedHeaders.authorization);
   if (typeof authorization === 'undefined') {
     return false;
   }
-  const authParts = checkAuthorizationHeaderFormat(authorization);
+  const authParts = checkAuthorizationHeaderFormat(authorization, sinchLogger);
   if (null === authParts) {
     return false;
   }
@@ -96,7 +101,7 @@ export const validateAuthenticationHeader = (
   const authorizationScheme = authParts[0].toLowerCase();
   const authorizationValue = authParts[1];
   if (authorizationScheme === 'basic') {
-    return validateBasicAuth(authorizationValue, applicationKey, applicationSecret);
+    return validateBasicAuth(authorizationValue, applicationKey, applicationSecret, sinchLogger);
   }
   if (authorizationScheme === 'application') {
     return validateApplicationAuth(
@@ -107,10 +112,11 @@ export const validateAuthenticationHeader = (
       path,
       body,
       method,
+      sinchLogger,
     );
   }
   // Other schemes than 'basic' or 'application' are not supported
-  console.error(`Scheme is not valid: ${authParts[0]}`);
+  sinchLogger.error(`Scheme is not valid: ${authParts[0]}`);
   return false;
 };
 
@@ -174,14 +180,15 @@ const validateApplicationAuth = (
   path: string,
   body: any,
   method: string,
+  sinchLogger: SinchLogger,
 ): boolean => {
   const authKeyAndSecret = authorizationValue.split(':');
   if(authKeyAndSecret.length !== 2) {
-    console.error('Invalid authorization value format provided');
+    sinchLogger.error('Invalid authorization value format provided');
     return false;
   }
   if(authKeyAndSecret[0] !== applicationKey) {
-    console.error('Application Key is not valid');
+    sinchLogger.error('Application Key is not valid');
     return false;
   }
 
@@ -198,7 +205,7 @@ const validateApplicationAuth = (
   const signature = calculateSignature(applicationSecret, stringToSign);
 
   if(authKeyAndSecret[1] !== signature) {
-    console.error('Invalid signature');
+    sinchLogger.error('Invalid signature');
     return false;
   }
 
@@ -227,11 +234,11 @@ const buildStringToSign = (
   return `${httpVerb}\n${contentMD5}\n${contentType}\n${canonicalizedHeaders}\n${canonicalizedResource}`;
 };
 
-const checkAuthorizationHeaderFormat = (authorizationHeader: string) => {
+const checkAuthorizationHeaderFormat = (authorizationHeader: string, sinchLogger: SinchLogger) => {
   const authParts = authorizationHeader.split(' ');
   if(authParts.length !== 2) {
     // The authorization header must be in 2 part: scheme and authorization value
-    console.error('Invalid authorization format provided');
+    sinchLogger.error('Invalid authorization format provided');
     return null;
   }
   return authParts;
@@ -241,14 +248,15 @@ const validateBasicAuth = (
   authorization: string,
   applicationKey: string,
   applicationSecret: string,
+  sinchLogger: SinchLogger,
 ): boolean => {
   const authKeyAndSecret = authorization.split(':');
   if(authKeyAndSecret.length !== 2) {
-    console.error('Invalid authorization value format provided');
+    sinchLogger.error('Invalid authorization value format provided');
     return false;
   }
   if(authKeyAndSecret[0] !== applicationKey || authKeyAndSecret[1] !== applicationSecret) {
-    console.error('Invalid credentials provided');
+    sinchLogger.error('Invalid credentials provided');
     return false;
   }
   return true;

--- a/packages/sdk-client/src/utils/authorization.helper.ts
+++ b/packages/sdk-client/src/utils/authorization.helper.ts
@@ -1,7 +1,6 @@
 import crypto from 'crypto';
 import { IncomingHttpHeaders } from 'http';
 import { RequestBody } from '../plugins/core/request-plugin';
-import { Logger, SinchLogger, resolveLogger } from '../logger';
 
 /**
  * Generate authorization header for application-signed requests (Verification and Voice)
@@ -73,7 +72,6 @@ export const validateWebhookSignature = (
  * @param {any} body - Incoming request's body
  * @param {string} path - Incoming request's path
  * @param {string} method - Incoming request's HTTP method
- * @param {Logger} logger
  * @return {boolean} - true if the authorization header is valid
  */
 export const validateAuthenticationHeader = (
@@ -83,16 +81,14 @@ export const validateAuthenticationHeader = (
   body: any,
   path: string,
   method: string,
-  logger? : Logger | null,
 ): boolean => {
-  const sinchLogger = new SinchLogger(resolveLogger(logger));
   const normalizedHeaders = normalizeHeaders(headers);
 
   const authorization = getHeader(normalizedHeaders.authorization);
   if (typeof authorization === 'undefined') {
     return false;
   }
-  const authParts = checkAuthorizationHeaderFormat(authorization, sinchLogger);
+  const authParts = checkAuthorizationHeaderFormat(authorization);
   if (null === authParts) {
     return false;
   }
@@ -100,7 +96,7 @@ export const validateAuthenticationHeader = (
   const authorizationScheme = authParts[0].toLowerCase();
   const authorizationValue = authParts[1];
   if (authorizationScheme === 'basic') {
-    return validateBasicAuth(authorizationValue, applicationKey, applicationSecret, sinchLogger);
+    return validateBasicAuth(authorizationValue, applicationKey, applicationSecret);
   }
   if (authorizationScheme === 'application') {
     return validateApplicationAuth(
@@ -111,11 +107,8 @@ export const validateAuthenticationHeader = (
       path,
       body,
       method,
-      sinchLogger,
     );
   }
-  // Other schemes than 'basic' or 'application' are not supported
-  sinchLogger.error(`Scheme is not valid: ${authParts[0]}`);
   return false;
 };
 
@@ -179,15 +172,12 @@ const validateApplicationAuth = (
   path: string,
   body: any,
   method: string,
-  sinchLogger: SinchLogger,
 ): boolean => {
   const authKeyAndSecret = authorizationValue.split(':');
   if(authKeyAndSecret.length !== 2) {
-    sinchLogger.error('Invalid authorization value format provided');
     return false;
   }
   if(authKeyAndSecret[0] !== applicationKey) {
-    sinchLogger.error('Application Key is not valid');
     return false;
   }
 
@@ -204,7 +194,6 @@ const validateApplicationAuth = (
   const signature = calculateSignature(applicationSecret, stringToSign);
 
   if(authKeyAndSecret[1] !== signature) {
-    sinchLogger.error('Invalid signature');
     return false;
   }
 
@@ -233,11 +222,9 @@ const buildStringToSign = (
   return `${httpVerb}\n${contentMD5}\n${contentType}\n${canonicalizedHeaders}\n${canonicalizedResource}`;
 };
 
-const checkAuthorizationHeaderFormat = (authorizationHeader: string, sinchLogger: SinchLogger) => {
+const checkAuthorizationHeaderFormat = (authorizationHeader: string) => {
   const authParts = authorizationHeader.split(' ');
   if(authParts.length !== 2) {
-    // The authorization header must be in 2 part: scheme and authorization value
-    sinchLogger.error('Invalid authorization format provided');
     return null;
   }
   return authParts;
@@ -247,15 +234,12 @@ const validateBasicAuth = (
   authorization: string,
   applicationKey: string,
   applicationSecret: string,
-  sinchLogger: SinchLogger,
 ): boolean => {
   const authKeyAndSecret = authorization.split(':');
   if(authKeyAndSecret.length !== 2) {
-    sinchLogger.error('Invalid authorization value format provided');
     return false;
   }
   if(authKeyAndSecret[0] !== applicationKey || authKeyAndSecret[1] !== applicationSecret) {
-    sinchLogger.error('Invalid credentials provided');
     return false;
   }
   return true;

--- a/packages/sdk-client/tests/api/api-client-options-helper.test.ts
+++ b/packages/sdk-client/tests/api/api-client-options-helper.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../../src';
 import { RequestOptions, RequestPlugin } from '../../src/plugins/core/request-plugin';
 import { ResponsePlugin, ResponsePluginContext } from '../../src/plugins/core/response-plugin';
+import * as console from 'node:console';
 
 const dummyRequestPlugin: RequestPlugin = {
   getName(): string {
@@ -189,14 +190,15 @@ describe('API Client Options helper', () => {
     // eslint-disable-next-line max-len
     it('should build some ApiClientOptions to perform API token authentication when both set of credentials are provided', () => {
       // Given
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
       const params: SinchClientParameters = {
         projectId: 'PROJECT_ID',
         keyId: 'KEY_ID',
         keySecret: 'KEY_SECRET',
         servicePlanId: 'SERVICE_PLAN_ID',
         apiToken: 'API_TOKEN',
+        logger: console,
       };
-      console.warn = jest.fn();
 
       // When
       const apiClientOptions = buildFlexibleOAuth2OrApiTokenApiClientOptions(params);
@@ -207,8 +209,8 @@ describe('API Client Options helper', () => {
       expect(apiClientOptions.requestPlugins?.length).toBe(1);
       expect(apiClientOptions.requestPlugins?.[0]).toBeInstanceOf(ApiTokenRequest);
       expect(apiClientOptions.responsePlugins).toBeUndefined();
-      expect(console.warn).toHaveBeenCalledWith(
-        'As the servicePlanId and the apiToken are provided, all other credentials will be disregarded.');
+      expect(console.warn).toHaveBeenCalledWith('[Sinch SDK][Warn] '
+        + 'As the servicePlanId and the apiToken are provided, all other credentials will be disregarded.');
     });
 
     it('should build some ApiClientOptions with additional plugins', () => {

--- a/packages/sdk-client/tests/api/api-client-options-helper.test.ts
+++ b/packages/sdk-client/tests/api/api-client-options-helper.test.ts
@@ -11,7 +11,6 @@ import {
 } from '../../src';
 import { RequestOptions, RequestPlugin } from '../../src/plugins/core/request-plugin';
 import { ResponsePlugin, ResponsePluginContext } from '../../src/plugins/core/response-plugin';
-import * as console from 'node:console';
 
 const dummyRequestPlugin: RequestPlugin = {
   getName(): string {

--- a/packages/sdk-client/tests/client/api-fetch-client.test.ts
+++ b/packages/sdk-client/tests/client/api-fetch-client.test.ts
@@ -268,6 +268,43 @@ describe('concurrent token refresh', () => {
   });
 });
 
+describe('logFailedResponse', () => {
+  it('should debug-log failed HTTP responses from the transport layer', async () => {
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+    mockedFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'bad request' }), {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: { 'x-request-id': 'req-123' },
+      }),
+    );
+
+    const apiClient = new ApiFetchClient({ requestPlugins: [] });
+
+    await expect(apiClient.processCall({
+      url: 'https://api.example.com/endpoint',
+      requestOptions: {
+        method: 'GET',
+        headers: new Headers(),
+        hostname: 'https://api.example.com',
+      },
+      apiName: 'TestAPI',
+      operationId: 'testOperation',
+    })).rejects.toThrow();
+
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[Sinch SDK][Debug] [TestAPI][testOperation][400]'),
+    );
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining('HTTP method: GET'),
+    );
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining('URL: https://api.example.com/endpoint'),
+    );
+    debugSpy.mockRestore();
+  });
+});
+
 describe('processFileResponse', () => {
 
   it('should return file buffer and file name when response is ok', async () => {

--- a/packages/sdk-client/tests/logger/logger.test.ts
+++ b/packages/sdk-client/tests/logger/logger.test.ts
@@ -1,0 +1,75 @@
+import { Logger, CONSOLE_LOGGER, NOOP_LOGGER, resolveLogger, SinchLogger } from '../../src/logger';
+
+describe('resolveLogger', () => {
+  it('should return CONSOLE_LOGGER when logger is undefined', () => {
+    expect(resolveLogger(undefined)).toBe(CONSOLE_LOGGER);
+  });
+
+  it('should return NOOP_LOGGER when logger is null', () => {
+    expect(resolveLogger(null)).toBe(NOOP_LOGGER);
+  });
+
+  it('should return the provided logger instance', () => {
+    const customLogger: Logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    expect(resolveLogger(customLogger)).toBe(customLogger);
+  });
+});
+
+describe('NOOP_LOGGER', () => {
+  it('should not invoke lazy message callbacks', () => {
+    const callback = jest.fn(() => 'should not run');
+    NOOP_LOGGER.debug(callback);
+    NOOP_LOGGER.info(callback);
+    NOOP_LOGGER.warn(callback);
+    NOOP_LOGGER.error(callback);
+    expect(callback).not.toHaveBeenCalled();
+  });
+});
+
+describe('SinchLogger', () => {
+  it('should prefix string messages', () => {
+    const baseLogger: Logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    const sinchLogger = new SinchLogger(baseLogger);
+    sinchLogger.warn('test message');
+    expect(baseLogger.warn).toHaveBeenCalledWith('[Sinch SDK][Warn] test message');
+  });
+
+  it('should pass lazy callbacks to the base logger without evaluating them upfront', () => {
+    const baseLogger: Logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    const sinchLogger = new SinchLogger(baseLogger);
+    const callback = jest.fn(() => 'lazy message');
+    sinchLogger.debug(callback);
+    expect(callback).not.toHaveBeenCalled();
+    expect(baseLogger.debug).toHaveBeenCalledWith(expect.any(Function));
+    const passedCallback = (baseLogger.debug as jest.Mock).mock.calls[0][0] as () => string;
+    expect(passedCallback()).toBe('[Sinch SDK][Debug] lazy message');
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should allow level-aware loggers to skip lazy callback evaluation', () => {
+    const callback = jest.fn(() => 'lazy message');
+    const levelAwareLogger: Logger = {
+      debug: () => {},
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    new SinchLogger(levelAwareLogger).debug(callback);
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sdk-client/tests/logger/logger.test.ts
+++ b/packages/sdk-client/tests/logger/logger.test.ts
@@ -1,4 +1,4 @@
-import { Logger, NOOP_LOGGER, resolveLogger, SinchLogger } from '../../src/logger';
+import { Logger, NOOP_LOGGER, resolveClientParameters, resolveLogger, SinchLogger } from '../../src/logger';
 
 describe('resolveLogger', () => {
   beforeEach(() => {
@@ -40,6 +40,18 @@ describe('resolveLogger', () => {
   it('should return the same instance when logger is already resolved', () => {
     const logger = resolveLogger(undefined);
     expect(resolveLogger(logger)).toBe(logger);
+  });
+});
+
+describe('resolveClientParameters', () => {
+  it('should always resolve logger on client parameters', () => {
+    expect(resolveClientParameters({}).logger).toBeInstanceOf(SinchLogger);
+    expect(resolveClientParameters({ logger: null }).logger).toBeInstanceOf(SinchLogger);
+  });
+
+  it('should return the same object when logger is already resolved', () => {
+    const resolved = resolveClientParameters({});
+    expect(resolveClientParameters(resolved)).toBe(resolved);
   });
 });
 

--- a/packages/sdk-client/tests/logger/logger.test.ts
+++ b/packages/sdk-client/tests/logger/logger.test.ts
@@ -1,22 +1,45 @@
-import { Logger, CONSOLE_LOGGER, NOOP_LOGGER, resolveLogger, SinchLogger } from '../../src/logger';
+import { Logger, NOOP_LOGGER, resolveLogger, SinchLogger } from '../../src/logger';
 
 describe('resolveLogger', () => {
-  it('should return CONSOLE_LOGGER when logger is undefined', () => {
-    expect(resolveLogger(undefined)).toBe(CONSOLE_LOGGER);
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
-  it('should return NOOP_LOGGER when logger is null', () => {
-    expect(resolveLogger(null)).toBe(NOOP_LOGGER);
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
-  it('should return the provided logger instance', () => {
+  it('should wrap CONSOLE_LOGGER when logger is undefined', () => {
+    const logger = resolveLogger(undefined);
+    expect(logger).toBeInstanceOf(SinchLogger);
+    logger.warn('test');
+    expect(console.warn).toHaveBeenCalledWith('[Sinch SDK][Warn] test');
+  });
+
+  it('should wrap NOOP_LOGGER when logger is null', () => {
+    const logger = resolveLogger(null);
+    expect(logger).toBeInstanceOf(SinchLogger);
+    const callback = jest.fn(() => 'silent');
+    logger.warn(callback);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should wrap the provided logger instance', () => {
     const customLogger: Logger = {
       debug: jest.fn(),
       info: jest.fn(),
       warn: jest.fn(),
       error: jest.fn(),
     };
-    expect(resolveLogger(customLogger)).toBe(customLogger);
+    const logger = resolveLogger(customLogger);
+    expect(logger).toBeInstanceOf(SinchLogger);
+    logger.warn('test message');
+    expect(customLogger.warn).toHaveBeenCalledWith('[Sinch SDK][Warn] test message');
+  });
+
+  it('should return the same instance when logger is already resolved', () => {
+    const logger = resolveLogger(undefined);
+    expect(resolveLogger(logger)).toBe(logger);
   });
 });
 

--- a/packages/sdk-client/tests/logger/logger.test.ts
+++ b/packages/sdk-client/tests/logger/logger.test.ts
@@ -1,4 +1,5 @@
-import { Logger, NOOP_LOGGER, resolveClientParameters, resolveLogger, SinchLogger } from '../../src/logger';
+import { Logger, NOOP_LOGGER, resolveClientParameters, resolveLogger } from '../../src/logger';
+import { isSinchLogger, SinchLogger } from '../../src/logger/sinch-logger';
 
 describe('resolveLogger', () => {
   beforeEach(() => {
@@ -11,14 +12,14 @@ describe('resolveLogger', () => {
 
   it('should wrap CONSOLE_LOGGER when logger is undefined', () => {
     const logger = resolveLogger(undefined);
-    expect(logger).toBeInstanceOf(SinchLogger);
+    expect(isSinchLogger(logger)).toBe(true);
     logger.warn('test');
     expect(console.warn).toHaveBeenCalledWith('[Sinch SDK][Warn] test');
   });
 
   it('should wrap NOOP_LOGGER when logger is null', () => {
     const logger = resolveLogger(null);
-    expect(logger).toBeInstanceOf(SinchLogger);
+    expect(isSinchLogger(logger)).toBe(true);
     const callback = jest.fn(() => 'silent');
     logger.warn(callback);
     expect(callback).not.toHaveBeenCalled();
@@ -32,7 +33,7 @@ describe('resolveLogger', () => {
       error: jest.fn(),
     };
     const logger = resolveLogger(customLogger);
-    expect(logger).toBeInstanceOf(SinchLogger);
+    expect(isSinchLogger(logger)).toBe(true);
     logger.warn('test message');
     expect(customLogger.warn).toHaveBeenCalledWith('[Sinch SDK][Warn] test message');
   });
@@ -45,8 +46,8 @@ describe('resolveLogger', () => {
 
 describe('resolveClientParameters', () => {
   it('should always resolve logger on client parameters', () => {
-    expect(resolveClientParameters({}).logger).toBeInstanceOf(SinchLogger);
-    expect(resolveClientParameters({ logger: null }).logger).toBeInstanceOf(SinchLogger);
+    expect(isSinchLogger(resolveClientParameters({}).logger)).toBe(true);
+    expect(isSinchLogger(resolveClientParameters({ logger: null }).logger)).toBe(true);
   });
 
   it('should return the same object when logger is already resolved', () => {

--- a/packages/sdk-core/src/sinch-client.ts
+++ b/packages/sdk-core/src/sinch-client.ts
@@ -4,7 +4,7 @@ import { NumbersService } from '@sinch/numbers';
 import { SmsService } from '@sinch/sms';
 import { VerificationService } from '@sinch/verification';
 import { VoiceService } from '@sinch/voice';
-import { SinchClientParameters, resolveLogger } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters } from '@sinch/sdk-client';
 import { ElasticSipTrunkingService } from '@sinch/elastic-sip-trunking';
 import { NumberLookupService } from '@sinch/number-lookup';
 
@@ -25,8 +25,8 @@ export class SinchClient {
    *
    * @param {SinchClientParameters} params - The object containing the Sinch credentials.
    */
-  constructor(params: SinchClientParameters) {
-    params.logger = resolveLogger(params.logger);
+  constructor(clientParams: SinchClientParameters) {
+    const params = resolveClientParameters(clientParams);
     this.conversation = new ConversationService(params);
     this.elasticSipTrunking = new ElasticSipTrunkingService(params);
     this.fax = new FaxService(params);

--- a/packages/sdk-core/src/sinch-client.ts
+++ b/packages/sdk-core/src/sinch-client.ts
@@ -4,7 +4,7 @@ import { NumbersService } from '@sinch/numbers';
 import { SmsService } from '@sinch/sms';
 import { VerificationService } from '@sinch/verification';
 import { VoiceService } from '@sinch/voice';
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveLogger } from '@sinch/sdk-client';
 import { ElasticSipTrunkingService } from '@sinch/elastic-sip-trunking';
 import { NumberLookupService } from '@sinch/number-lookup';
 
@@ -26,9 +26,7 @@ export class SinchClient {
    * @param {SinchClientParameters} params - The object containing the Sinch credentials.
    */
   constructor(params: SinchClientParameters) {
-    if (!params.logger) {
-      params.logger = console;
-    }
+    params.logger = resolveLogger(params.logger);
     this.conversation = new ConversationService(params);
     this.elasticSipTrunking = new ElasticSipTrunkingService(params);
     this.fax = new FaxService(params);

--- a/packages/sdk-core/src/sinch-client.ts
+++ b/packages/sdk-core/src/sinch-client.ts
@@ -26,6 +26,9 @@ export class SinchClient {
    * @param {SinchClientParameters} params - The object containing the Sinch credentials.
    */
   constructor(params: SinchClientParameters) {
+    if (!params.logger) {
+      params.logger = console;
+    }
     this.conversation = new ConversationService(params);
     this.elasticSipTrunking = new ElasticSipTrunkingService(params);
     this.fax = new FaxService(params);

--- a/packages/sms/src/rest/v1/sms-domain-api.ts
+++ b/packages/sms/src/rest/v1/sms-domain-api.ts
@@ -4,8 +4,6 @@ import {
   SmsRegion,
   UnifiedCredentials,
   ServicePlanIdCredentials,
-  SinchLogger,
-  resolveLogger,
 } from '@sinch/sdk-client';
 import { LazySmsApiClient } from './sms-service';
 
@@ -61,7 +59,7 @@ export class SmsDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
+      this.lazyClient.sharedConfig.logger!.error(
         'Impossible to assign the new credentials to the SMS API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/sms/src/rest/v1/sms-domain-api.ts
+++ b/packages/sms/src/rest/v1/sms-domain-api.ts
@@ -5,6 +5,7 @@ import {
   UnifiedCredentials,
   ServicePlanIdCredentials,
   SinchLogger,
+  resolveLogger,
 } from '@sinch/sdk-client';
 import { LazySmsApiClient } from './sms-service';
 
@@ -60,7 +61,7 @@ export class SmsDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
         'Impossible to assign the new credentials to the SMS API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/sms/src/rest/v1/sms-domain-api.ts
+++ b/packages/sms/src/rest/v1/sms-domain-api.ts
@@ -4,6 +4,7 @@ import {
   SmsRegion,
   UnifiedCredentials,
   ServicePlanIdCredentials,
+  SinchLogger,
 } from '@sinch/sdk-client';
 import { LazySmsApiClient } from './sms-service';
 
@@ -59,7 +60,9 @@ export class SmsDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      console.error('Impossible to assign the new credentials to the SMS API');
+      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+        'Impossible to assign the new credentials to the SMS API',
+      );
       this.lazyClient.sharedConfig = parametersBackup;
       throw error;
     }

--- a/packages/sms/src/rest/v1/sms-domain-api.ts
+++ b/packages/sms/src/rest/v1/sms-domain-api.ts
@@ -59,7 +59,7 @@ export class SmsDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      this.lazyClient.sharedConfig.logger!.error(
+      this.lazyClient.sharedConfig.logger.error(
         'Impossible to assign the new credentials to the SMS API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/sms/src/rest/v1/sms-service.ts
+++ b/packages/sms/src/rest/v1/sms-service.ts
@@ -6,7 +6,8 @@ import {
   SMS_HOSTNAME,
   SmsRegion,
   SupportedSmsRegion, UnifiedCredentials,
-  resolveLogger,
+  LazyApiClient,
+  resolveClientParameters,
 } from '@sinch/sdk-client';
 import { GroupsApi } from './groups';
 import { DeliveryReportsApi } from './delivery-reports';
@@ -17,19 +18,16 @@ export const DEFAULT_SMS_REGION_DEPRECATION_WARNING = '** DEPRECATION NOTICE ** 
   + 'The "smsRegion" property will become mandatory in the next major version of the SDK and not default '
   + 'to "us" anymore. Please set it to a valid region.';
 
-export class LazySmsApiClient {
-  apiFetchClient?: ApiFetchClient;
-  constructor(public sharedConfig: SinchClientParameters) {}
-
+export class LazySmsApiClient extends LazyApiClient {
   public getApiClient(): ApiFetchClient {
     if (!this.apiFetchClient) {
       const region = this.sharedConfig.smsRegion ?? SmsRegion.UNITED_STATES;
       // Deprecation Notice - to remove in 2.0
       if (!this.sharedConfig.smsRegion && !this.sharedConfig.smsHostname) {
-        this.sharedConfig.logger!.warn(DEFAULT_SMS_REGION_DEPRECATION_WARNING);
+        this.sharedConfig.logger.warn(DEFAULT_SMS_REGION_DEPRECATION_WARNING);
       }
       if(!Object.values(SupportedSmsRegion).includes(region as SupportedSmsRegion)) {
-        this.sharedConfig.logger!.warn(
+        this.sharedConfig.logger.warn(
           `The region "${region}" is not known as a supported region for the SMS API`,
         );
       }
@@ -45,10 +43,6 @@ export class LazySmsApiClient {
   private buildHostname(region: SmsRegion, useZapStack: boolean) {
     const formattedRegion = region !== '' ? `${region}.` : '';
     return formatRegionalizedHostname(SMS_HOSTNAME, `${useZapStack?'zt.':''}${formattedRegion}`);
-  }
-
-  public resetApiClient() {
-    this.apiFetchClient = undefined;
   }
 }
 
@@ -80,7 +74,6 @@ export class SmsService {
    * @param {SinchClientParameters} params - an Object containing the necessary properties to initialize the service
    */
   constructor(params: SinchClientParameters) {
-    params.logger = resolveLogger(params.logger);
     this.lazyClient = new LazySmsApiClient(params);
 
     this.groups = new GroupsApi(this.lazyClient);
@@ -90,7 +83,7 @@ export class SmsService {
   }
 
   public setApiClientConfig(newParams: SinchClientParameters) {
-    this.lazyClient.sharedConfig = newParams;
+    this.lazyClient.sharedConfig = resolveClientParameters(newParams);
     this.lazyClient.resetApiClient();
   }
 
@@ -122,7 +115,7 @@ export class SmsService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      this.lazyClient.sharedConfig.logger!.error(
+      this.lazyClient.sharedConfig.logger.error(
         'Impossible to assign the new credentials to the SMS API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/sms/src/rest/v1/sms-service.ts
+++ b/packages/sms/src/rest/v1/sms-service.ts
@@ -7,6 +7,7 @@ import {
   SmsRegion,
   SinchLogger,
   SupportedSmsRegion, UnifiedCredentials,
+  resolveLogger,
 } from '@sinch/sdk-client';
 import { GroupsApi } from './groups';
 import { DeliveryReportsApi } from './delivery-reports';
@@ -26,10 +27,10 @@ export class LazySmsApiClient {
       const region = this.sharedConfig.smsRegion ?? SmsRegion.UNITED_STATES;
       // Deprecation Notice - to remove in 2.0
       if (!this.sharedConfig.smsRegion && !this.sharedConfig.smsHostname) {
-        console.warn(DEFAULT_SMS_REGION_DEPRECATION_WARNING);
+        new SinchLogger(resolveLogger(this.sharedConfig.logger)).warn(DEFAULT_SMS_REGION_DEPRECATION_WARNING);
       }
       if(!Object.values(SupportedSmsRegion).includes(region as SupportedSmsRegion)) {
-        new SinchLogger(this.sharedConfig.logger ?? console).warn(
+        new SinchLogger(resolveLogger(this.sharedConfig.logger)).warn(
           `The region "${region}" is not known as a supported region for the SMS API`,
         );
       }
@@ -80,6 +81,7 @@ export class SmsService {
    * @param {SinchClientParameters} params - an Object containing the necessary properties to initialize the service
    */
   constructor(params: SinchClientParameters) {
+    params.logger = resolveLogger(params.logger);
     this.lazyClient = new LazySmsApiClient(params);
 
     this.groups = new GroupsApi(this.lazyClient);
@@ -121,7 +123,7 @@ export class SmsService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
         'Impossible to assign the new credentials to the SMS API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/sms/src/rest/v1/sms-service.ts
+++ b/packages/sms/src/rest/v1/sms-service.ts
@@ -74,7 +74,8 @@ export class SmsService {
    * @param {SinchClientParameters} params - an Object containing the necessary properties to initialize the service
    */
   constructor(params: SinchClientParameters) {
-    this.lazyClient = new LazySmsApiClient(params);
+    const resolvedParams = resolveClientParameters(params);
+    this.lazyClient = new LazySmsApiClient(resolvedParams);
 
     this.groups = new GroupsApi(this.lazyClient);
     this.deliveryReports = new DeliveryReportsApi(this.lazyClient);
@@ -83,7 +84,8 @@ export class SmsService {
   }
 
   public setApiClientConfig(newParams: SinchClientParameters) {
-    this.lazyClient.sharedConfig = resolveClientParameters(newParams);
+    const resolvedParams = resolveClientParameters(newParams);
+    this.lazyClient.sharedConfig = resolvedParams;
     this.lazyClient.resetApiClient();
   }
 

--- a/packages/sms/src/rest/v1/sms-service.ts
+++ b/packages/sms/src/rest/v1/sms-service.ts
@@ -5,6 +5,7 @@ import {
   SinchClientParameters,
   SMS_HOSTNAME,
   SmsRegion,
+  SinchLogger,
   SupportedSmsRegion, UnifiedCredentials,
 } from '@sinch/sdk-client';
 import { GroupsApi } from './groups';
@@ -28,7 +29,9 @@ export class LazySmsApiClient {
         console.warn(DEFAULT_SMS_REGION_DEPRECATION_WARNING);
       }
       if(!Object.values(SupportedSmsRegion).includes(region as SupportedSmsRegion)) {
-        console.warn(`The region "${region}" is not known as a supported region for the SMS API`);
+        new SinchLogger(this.sharedConfig.logger ?? console).warn(
+          `The region "${region}" is not known as a supported region for the SMS API`,
+        );
       }
       const apiClientOptions = buildFlexibleOAuth2OrApiTokenApiClientOptions(this.sharedConfig);
       this.apiFetchClient = new ApiFetchClient(apiClientOptions);
@@ -118,7 +121,9 @@ export class SmsService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      console.error('Impossible to assign the new credentials to the SMS API');
+      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+        'Impossible to assign the new credentials to the SMS API',
+      );
       this.lazyClient.sharedConfig = parametersBackup;
       throw error;
     }

--- a/packages/sms/src/rest/v1/sms-service.ts
+++ b/packages/sms/src/rest/v1/sms-service.ts
@@ -5,7 +5,6 @@ import {
   SinchClientParameters,
   SMS_HOSTNAME,
   SmsRegion,
-  SinchLogger,
   SupportedSmsRegion, UnifiedCredentials,
   resolveLogger,
 } from '@sinch/sdk-client';
@@ -27,10 +26,10 @@ export class LazySmsApiClient {
       const region = this.sharedConfig.smsRegion ?? SmsRegion.UNITED_STATES;
       // Deprecation Notice - to remove in 2.0
       if (!this.sharedConfig.smsRegion && !this.sharedConfig.smsHostname) {
-        new SinchLogger(resolveLogger(this.sharedConfig.logger)).warn(DEFAULT_SMS_REGION_DEPRECATION_WARNING);
+        this.sharedConfig.logger!.warn(DEFAULT_SMS_REGION_DEPRECATION_WARNING);
       }
       if(!Object.values(SupportedSmsRegion).includes(region as SupportedSmsRegion)) {
-        new SinchLogger(resolveLogger(this.sharedConfig.logger)).warn(
+        this.sharedConfig.logger!.warn(
           `The region "${region}" is not known as a supported region for the SMS API`,
         );
       }
@@ -123,7 +122,7 @@ export class SmsService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
+      this.lazyClient.sharedConfig.logger!.error(
         'Impossible to assign the new credentials to the SMS API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/sms/tests/rest/v1/batches/batches-api.test.ts
+++ b/packages/sms/tests/rest/v1/batches/batches-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters, textToHex } from '@sinch/sdk-client';
+import { SinchClientParameters, textToHex, resolveClientParameters }from '@sinch/sdk-client';
 import {
   BatchesApi,
   BatchesApiFixture,
@@ -17,7 +17,7 @@ describe('BatchesApi', () => {
       servicePlanId: 'SERVICE_PLAN_ID',
       apiToken: 'API_TOKEN',
     };
-    const lazyClient = new LazySmsApiClient(paramsWithServicePlanId);
+    const lazyClient = new LazySmsApiClient(resolveClientParameters(paramsWithServicePlanId));
     batchesApi = new BatchesApi(lazyClient);
   });
 

--- a/packages/sms/tests/rest/v1/delivery-reports/delivery-reports-api.test.ts
+++ b/packages/sms/tests/rest/v1/delivery-reports/delivery-reports-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   DeliveryReportsApi,
   DeliveryReportsApiFixture,
@@ -17,7 +17,7 @@ describe('DeliveryReportsApi', () => {
       servicePlanId: 'SERVICE_PLAN_ID',
       apiToken: 'API_TOKEN',
     };
-    const lazyClient = new LazySmsApiClient(paramsWithServicePlanId);
+    const lazyClient = new LazySmsApiClient(resolveClientParameters(paramsWithServicePlanId));
     deliveryReportsApi = new DeliveryReportsApi(lazyClient);
   });
 

--- a/packages/sms/tests/rest/v1/groups/groups-api.test.ts
+++ b/packages/sms/tests/rest/v1/groups/groups-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   GroupsApi,
   GroupsApiFixture,
@@ -17,7 +17,7 @@ describe('GroupsApi', () => {
       servicePlanId: 'SERVICE_PLAN_ID',
       apiToken: 'API_TOKEN',
     };
-    const lazyClient = new LazySmsApiClient(paramsWithServicePlanId);
+    const lazyClient = new LazySmsApiClient(resolveClientParameters(paramsWithServicePlanId));
     groupsApi = new GroupsApi(lazyClient);
   });
 

--- a/packages/sms/tests/rest/v1/inbounds/inbounds-api.test.ts
+++ b/packages/sms/tests/rest/v1/inbounds/inbounds-api.test.ts
@@ -1,4 +1,4 @@
-import { SinchClientParameters } from '@sinch/sdk-client';
+import { SinchClientParameters, resolveClientParameters }from '@sinch/sdk-client';
 import {
   InboundsApi,
   InboundsApiFixture,
@@ -17,7 +17,7 @@ describe('InboundsApi', () => {
       servicePlanId: 'SERVICE_PLAN_ID',
       apiToken: 'API_TOKEN',
     };
-    const lazyClient = new LazySmsApiClient(paramsWithServicePlanId);
+    const lazyClient = new LazySmsApiClient(resolveClientParameters(paramsWithServicePlanId));
     inboundsApi = new InboundsApi(lazyClient);
   });
 

--- a/packages/sms/tests/rest/v1/sms-api.test.ts
+++ b/packages/sms/tests/rest/v1/sms-api.test.ts
@@ -58,8 +58,8 @@ describe('SMS API', () => {
     paramsWithProjectId.smsRegion = 'bzh';
     smsApi = new SmsDomainApi(lazyClientWithProjectId, 'dummy');
     expect(smsApi.client?.apiClientOptions.hostname).toBe('https://zt.bzh.sms.api.sinch.com');
-    expect(warnSpy).toHaveBeenCalledWith(
-      'The region "bzh" is not known as a supported region for the SMS API');
+    expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] '
+      + 'The region "bzh" is not known as a supported region for the SMS API');
   });
 
   it('should use the hostname parameter when using projectId credentials', () => {
@@ -174,8 +174,8 @@ describe('SMS API', () => {
       ...paramsWithProjectId,
       smsRegion: SmsRegion.BRAZIL,
     });
-    expect(warnSpy).toHaveBeenCalledWith(
-      'As the servicePlanId and the apiToken are provided, all other credentials will be disregarded.');
+    expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] '
+      + 'As the servicePlanId and the apiToken are provided, all other credentials will be disregarded.');
     expect(smsApi.client?.apiClientOptions.projectId).toBe('SERVICE_PLAN_ID');
     expect(smsApi.client?.apiClientOptions.hostname).toBe('https://br.sms.api.sinch.com');
   });
@@ -184,6 +184,7 @@ describe('SMS API', () => {
     smsApi = new SmsDomainApi(lazyClientWithProjectId, 'dummy');
     expect(() => smsApi.setCredentials({ projectId: '' }))
       .toThrow('Invalid parameters for the SMS API: check your configuration');
-    expect(errorSpy).toHaveBeenCalledWith('Impossible to assign the new credentials to the SMS API');
+    expect(errorSpy).toHaveBeenCalledWith('[Sinch SDK][Error] '
+      + 'Impossible to assign the new credentials to the SMS API');
   });
 });

--- a/packages/sms/tests/rest/v1/sms-api.test.ts
+++ b/packages/sms/tests/rest/v1/sms-api.test.ts
@@ -48,14 +48,14 @@ describe('SMS API', () => {
   });
 
   it('should change the URL when specifying a different region', () => {
-    paramsWithServicePlanId.smsRegion = SmsRegion.CANADA;
+    lazyClientWithServicePlanId.sharedConfig.smsRegion = SmsRegion.CANADA;
     smsApi = new SmsDomainApi(lazyClientWithServicePlanId, 'dummy');
     expect(warnSpy).toHaveBeenCalledTimes(0);
     expect(smsApi.client?.apiClientOptions.hostname).toBe('https://ca.sms.api.sinch.com');
   });
 
   it('should log a warning when using an unsupported region', async () => {
-    paramsWithProjectId.smsRegion = 'bzh';
+    lazyClientWithProjectId.sharedConfig.smsRegion = 'bzh';
     smsApi = new SmsDomainApi(lazyClientWithProjectId, 'dummy');
     expect(smsApi.client?.apiClientOptions.hostname).toBe('https://zt.bzh.sms.api.sinch.com');
     expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] '
@@ -63,14 +63,14 @@ describe('SMS API', () => {
   });
 
   it('should use the hostname parameter when using projectId credentials', () => {
-    paramsWithProjectId.smsHostname = CUSTOM_HOSTNAME;
+    lazyClientWithProjectId.sharedConfig.smsHostname = CUSTOM_HOSTNAME;
     smsApi = new SmsDomainApi(lazyClientWithProjectId, 'dummy');
     expect(warnSpy).toHaveBeenCalledTimes(0);
     expect(smsApi.client?.apiClientOptions.hostname).toBe(CUSTOM_HOSTNAME);
   });
 
   it('should use the hostname parameter when using servicePlanId credentials', () => {
-    paramsWithServicePlanId.smsHostname = CUSTOM_HOSTNAME;
+    lazyClientWithServicePlanId.sharedConfig.smsHostname = CUSTOM_HOSTNAME;
     smsApi = new SmsDomainApi(lazyClientWithServicePlanId, 'dummy');
     expect(warnSpy).toHaveBeenCalledTimes(0);
     expect(smsApi.client?.apiClientOptions.hostname).toBe(CUSTOM_HOSTNAME);

--- a/packages/sms/tests/rest/v1/sms-api.test.ts
+++ b/packages/sms/tests/rest/v1/sms-api.test.ts
@@ -34,7 +34,7 @@ describe('SMS API', () => {
   it('should initialize the client with unified credentials and use the "zt." URL', () => {
     smsApi = new SmsDomainApi(lazyClientWithProjectId, 'dummy');
     expect(smsApi.client).toBeDefined();
-    expect(warnSpy).toHaveBeenCalledWith(DEFAULT_SMS_REGION_DEPRECATION_WARNING);
+    expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] ' + DEFAULT_SMS_REGION_DEPRECATION_WARNING);
     expect(smsApi.client?.apiClientOptions.projectId).toBe('PROJECT_ID');
     expect(smsApi.client?.apiClientOptions.hostname).toBe('https://zt.us.sms.api.sinch.com');
   });
@@ -42,7 +42,7 @@ describe('SMS API', () => {
   it('should initialize the client with servicePlanId credentials and use standard URL', () => {
     smsApi = new SmsDomainApi(lazyClientWithServicePlanId, 'dummy');
     expect(smsApi.client).toBeDefined();
-    expect(warnSpy).toHaveBeenCalledWith(DEFAULT_SMS_REGION_DEPRECATION_WARNING);
+    expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] ' + DEFAULT_SMS_REGION_DEPRECATION_WARNING);
     expect(smsApi.client?.apiClientOptions.projectId).toBe('SERVICE_PLAN_ID');
     expect(smsApi.client?.apiClientOptions.hostname).toBe('https://us.sms.api.sinch.com');
   });
@@ -87,7 +87,7 @@ describe('SMS API', () => {
   it ('should update the region with OAuth2 credentials', () => {
     smsApi = new SmsDomainApi(lazyClientWithProjectId, 'dummy');
     expect(smsApi.client).toBeDefined();
-    expect(warnSpy).toHaveBeenCalledWith(DEFAULT_SMS_REGION_DEPRECATION_WARNING);
+    expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] ' + DEFAULT_SMS_REGION_DEPRECATION_WARNING);
     expect(smsApi.client?.apiClientOptions.hostname).toBe('https://zt.us.sms.api.sinch.com');
     smsApi.setRegion(SmsRegion.UNITED_STATES);
     expect(smsApi.client?.apiClientOptions.hostname).toBe('https://zt.us.sms.api.sinch.com');
@@ -102,7 +102,7 @@ describe('SMS API', () => {
   it ('should update the region with servicePlanId credentials', () => {
     smsApi = new SmsDomainApi(lazyClientWithServicePlanId, 'dummy');
     expect(smsApi.client).toBeDefined();
-    expect(warnSpy).toHaveBeenCalledWith(DEFAULT_SMS_REGION_DEPRECATION_WARNING);
+    expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] ' + DEFAULT_SMS_REGION_DEPRECATION_WARNING);
     expect(smsApi.client?.apiClientOptions.hostname).toBe('https://us.sms.api.sinch.com');
     smsApi.setRegion(SmsRegion.UNITED_STATES);
     expect(smsApi.client?.apiClientOptions.hostname).toBe('https://us.sms.api.sinch.com');
@@ -123,7 +123,7 @@ describe('SMS API', () => {
   it('should update the credentials and URL when adding SMS credentials to the unified credentials', () => {
     smsApi = new SmsDomainApi(lazyClientWithProjectId, 'dummy');
     expect(smsApi.client).toBeDefined();
-    expect(warnSpy).toHaveBeenCalledWith(DEFAULT_SMS_REGION_DEPRECATION_WARNING);
+    expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] ' + DEFAULT_SMS_REGION_DEPRECATION_WARNING);
     expect(smsApi.client?.apiClientOptions.projectId).toBe('PROJECT_ID');
     expect(smsApi.client?.apiClientOptions.hostname).toBe('https://zt.us.sms.api.sinch.com');
     smsApi.setCredentials({
@@ -137,7 +137,7 @@ describe('SMS API', () => {
   it('should update the credentials and URL when adding SMS credentials on BR region to the unified credentials', () => {
     smsApi = new SmsDomainApi(lazyClientWithProjectId, 'dummy');
     expect(smsApi.client).toBeDefined();
-    expect(warnSpy).toHaveBeenCalledWith(DEFAULT_SMS_REGION_DEPRECATION_WARNING);
+    expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] ' + DEFAULT_SMS_REGION_DEPRECATION_WARNING);
     expect(smsApi.client?.apiClientOptions.projectId).toBe('PROJECT_ID');
     expect(smsApi.client?.apiClientOptions.hostname).toBe('https://zt.us.sms.api.sinch.com');
     smsApi.setCredentials({
@@ -152,7 +152,7 @@ describe('SMS API', () => {
   it('should not update the credentials nor URL when adding unified credentials to the SMS credentials', () => {
     smsApi = new SmsDomainApi(lazyClientWithServicePlanId, 'dummy');
     expect(smsApi.client).toBeDefined();
-    expect(warnSpy).toHaveBeenCalledWith(DEFAULT_SMS_REGION_DEPRECATION_WARNING);
+    expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] ' + DEFAULT_SMS_REGION_DEPRECATION_WARNING);
     expect(smsApi.client?.apiClientOptions.projectId).toBe('SERVICE_PLAN_ID');
     expect(smsApi.client?.apiClientOptions.hostname).toBe('https://us.sms.api.sinch.com');
     smsApi.setCredentials({
@@ -166,7 +166,7 @@ describe('SMS API', () => {
   it('should update the region in the URL when adding unified credentials and region to the SMS credentials', () => {
     smsApi = new SmsDomainApi(lazyClientWithServicePlanId, 'dummy');
     expect(smsApi.client).toBeDefined();
-    expect(warnSpy).toHaveBeenCalledWith(DEFAULT_SMS_REGION_DEPRECATION_WARNING);
+    expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] ' + DEFAULT_SMS_REGION_DEPRECATION_WARNING);
     warnSpy.mockClear();
     expect(smsApi.client?.apiClientOptions.projectId).toBe('SERVICE_PLAN_ID');
     expect(smsApi.client?.apiClientOptions.hostname).toBe('https://us.sms.api.sinch.com');

--- a/packages/sms/tests/rest/v1/sms-api.test.ts
+++ b/packages/sms/tests/rest/v1/sms-api.test.ts
@@ -1,4 +1,4 @@
-import { ApiHostname, ServicePlanIdCredentials, SmsRegion, UnifiedCredentials } from '@sinch/sdk-client';
+import { ApiHostname, ServicePlanIdCredentials, SmsRegion, UnifiedCredentials, resolveClientParameters } from '@sinch/sdk-client';
 import { DEFAULT_SMS_REGION_DEPRECATION_WARNING, LazySmsApiClient, SmsDomainApi } from '../../../src';
 
 describe('SMS API', () => {
@@ -23,8 +23,8 @@ describe('SMS API', () => {
     };
     warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    lazyClientWithProjectId = new LazySmsApiClient(paramsWithProjectId);
-    lazyClientWithServicePlanId = new LazySmsApiClient(paramsWithServicePlanId);
+    lazyClientWithProjectId = new LazySmsApiClient(resolveClientParameters(paramsWithProjectId));
+    lazyClientWithServicePlanId = new LazySmsApiClient(resolveClientParameters(paramsWithServicePlanId));
   });
 
   afterEach(() => {

--- a/packages/sms/tests/rest/v1/sms-service.test.ts
+++ b/packages/sms/tests/rest/v1/sms-service.test.ts
@@ -189,7 +189,8 @@ describe('SMS Service', () => {
     const smsService = new SmsService(params);
     expect(() => smsService.setCredentials({ projectId: '' }))
       .toThrow('Invalid parameters for the SMS API: check your configuration');
-    expect(errorSpy).toHaveBeenCalledWith('Impossible to assign the new credentials to the SMS API');
+    expect(errorSpy).toHaveBeenCalledWith('[Sinch SDK][Error] '
+      + 'Impossible to assign the new credentials to the SMS API');
 
     // Then
     expect(smsService.batches.client.apiClientOptions.projectId).toBe('PROJECT_ID');

--- a/packages/sms/tests/rest/v1/sms-service.test.ts
+++ b/packages/sms/tests/rest/v1/sms-service.test.ts
@@ -59,7 +59,7 @@ describe('SMS Service', () => {
     expect(smsService.deliveryReports.client.apiClientOptions.hostname).toBe(DEFAULT_HOSTNAME);
     expect(smsService.inbounds.client.apiClientOptions.hostname).toBe(DEFAULT_HOSTNAME);
     expect(smsService.groups.client.apiClientOptions.hostname).toBe(DEFAULT_HOSTNAME);
-    expect(warnSpy).toHaveBeenCalledWith(DEFAULT_SMS_REGION_DEPRECATION_WARNING);
+    expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] ' + DEFAULT_SMS_REGION_DEPRECATION_WARNING);
   });
 
   it('should update the API client for all the subdomains', () => {

--- a/packages/verification/src/rest/v1/callbacks/callbacks-webhook.ts
+++ b/packages/verification/src/rest/v1/callbacks/callbacks-webhook.ts
@@ -38,7 +38,7 @@ export class VerificationCallbackWebhooks implements CallbackProcessor<Verificat
     return validateAuthenticationHeader(
       this.sinchClientParameters.applicationKey,
       this.sinchClientParameters.applicationSecret,
-      headers, body, path, method, this.sinchClientParameters.logger);
+      headers, body, path, method);
   }
 
   /**

--- a/packages/verification/src/rest/v1/callbacks/callbacks-webhook.ts
+++ b/packages/verification/src/rest/v1/callbacks/callbacks-webhook.ts
@@ -38,7 +38,7 @@ export class VerificationCallbackWebhooks implements CallbackProcessor<Verificat
     return validateAuthenticationHeader(
       this.sinchClientParameters.applicationKey,
       this.sinchClientParameters.applicationSecret,
-      headers, body, path, method);
+      headers, body, path, method, this.sinchClientParameters.logger);
   }
 
   /**
@@ -63,8 +63,7 @@ export class VerificationCallbackWebhooks implements CallbackProcessor<Verificat
           throw new Error(`Unknown Verification event type: ${eventBody.event}`);
       }
     }
-    console.log(`Unknown Verification event structure:\n${JSON.stringify(eventBody)}`);
-    throw new Error('Unknown Verification event');
+    throw new Error(`Unknown Verification event: ${JSON.stringify(eventBody)}`);
   }
 
   /**

--- a/packages/verification/src/rest/v1/verification-domain-api.ts
+++ b/packages/verification/src/rest/v1/verification-domain-api.ts
@@ -3,6 +3,7 @@ import {
   ApiClient,
   ApplicationCredentials,
   SinchLogger,
+  resolveLogger,
 } from '@sinch/sdk-client';
 import { LazyVerificationApiClient } from './verification-service';
 
@@ -49,7 +50,7 @@ export class VerificationDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
         'Impossible to assign the new credentials to the Verification API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/verification/src/rest/v1/verification-domain-api.ts
+++ b/packages/verification/src/rest/v1/verification-domain-api.ts
@@ -48,7 +48,7 @@ export class VerificationDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      this.lazyClient.sharedConfig.logger!.error(
+      this.lazyClient.sharedConfig.logger.error(
         'Impossible to assign the new credentials to the Verification API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/verification/src/rest/v1/verification-domain-api.ts
+++ b/packages/verification/src/rest/v1/verification-domain-api.ts
@@ -2,6 +2,7 @@ import {
   Api,
   ApiClient,
   ApplicationCredentials,
+  SinchLogger,
 } from '@sinch/sdk-client';
 import { LazyVerificationApiClient } from './verification-service';
 
@@ -48,7 +49,9 @@ export class VerificationDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      console.error('Impossible to assign the new credentials to the Verification API');
+      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+        'Impossible to assign the new credentials to the Verification API',
+      );
       this.lazyClient.sharedConfig = parametersBackup;
       throw error;
     }

--- a/packages/verification/src/rest/v1/verification-domain-api.ts
+++ b/packages/verification/src/rest/v1/verification-domain-api.ts
@@ -2,8 +2,6 @@ import {
   Api,
   ApiClient,
   ApplicationCredentials,
-  SinchLogger,
-  resolveLogger,
 } from '@sinch/sdk-client';
 import { LazyVerificationApiClient } from './verification-service';
 
@@ -50,7 +48,7 @@ export class VerificationDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
+      this.lazyClient.sharedConfig.logger!.error(
         'Impossible to assign the new credentials to the Verification API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/verification/src/rest/v1/verification-service.ts
+++ b/packages/verification/src/rest/v1/verification-service.ts
@@ -4,15 +4,13 @@ import {
   buildApplicationSignedApiClientOptions,
   SinchClientParameters,
   VERIFICATION_HOSTNAME,
-  resolveLogger,
+  LazyApiClient,
+  resolveClientParameters,
 } from '@sinch/sdk-client';
 import { VerificationStatusApi } from './verification-status';
 import { VerificationsApi } from './verifications';
 
-export class LazyVerificationApiClient {
-  apiFetchClient?: ApiFetchClient;
-  constructor(public sharedConfig: SinchClientParameters) {}
-
+export class LazyVerificationApiClient extends LazyApiClient {
   public getApiClient(): ApiFetchClient {
     if (!this.apiFetchClient) {
       const apiClientOptions = buildApplicationSignedApiClientOptions(this.sharedConfig, 'Verification');
@@ -20,10 +18,6 @@ export class LazyVerificationApiClient {
       this.apiFetchClient.apiClientOptions.hostname = this.sharedConfig.verificationHostname ?? VERIFICATION_HOSTNAME;
     }
     return this.apiFetchClient;
-  }
-
-  public resetApiClient() {
-    this.apiFetchClient = undefined;
   }
 }
 
@@ -48,7 +42,6 @@ export class VerificationService {
    * @param {SinchClientParameters} params - an Object containing the necessary properties to initialize the service
    */
   constructor(params: SinchClientParameters) {
-    params.logger = resolveLogger(params.logger);
     this.lazyClient = new LazyVerificationApiClient(params);
 
     this.verificationStatus = new VerificationStatusApi(this.lazyClient);
@@ -56,7 +49,7 @@ export class VerificationService {
   }
 
   public setApiClientConfig(newParams: SinchClientParameters) {
-    this.lazyClient.sharedConfig = newParams;
+    this.lazyClient.sharedConfig = resolveClientParameters(newParams);
     this.lazyClient.resetApiClient();
   }
 
@@ -79,7 +72,7 @@ export class VerificationService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      this.lazyClient.sharedConfig.logger!.error(
+      this.lazyClient.sharedConfig.logger.error(
         'Impossible to assign the new credentials to the Verification API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/verification/src/rest/v1/verification-service.ts
+++ b/packages/verification/src/rest/v1/verification-service.ts
@@ -3,7 +3,6 @@ import {
   ApplicationCredentials,
   buildApplicationSignedApiClientOptions,
   SinchClientParameters,
-  SinchLogger,
   VERIFICATION_HOSTNAME,
   resolveLogger,
 } from '@sinch/sdk-client';
@@ -80,7 +79,7 @@ export class VerificationService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
+      this.lazyClient.sharedConfig.logger!.error(
         'Impossible to assign the new credentials to the Verification API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/verification/src/rest/v1/verification-service.ts
+++ b/packages/verification/src/rest/v1/verification-service.ts
@@ -3,6 +3,7 @@ import {
   ApplicationCredentials,
   buildApplicationSignedApiClientOptions,
   SinchClientParameters,
+  SinchLogger,
   VERIFICATION_HOSTNAME,
 } from '@sinch/sdk-client';
 import { VerificationStatusApi } from './verification-status';
@@ -77,7 +78,9 @@ export class VerificationService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      console.error('Impossible to assign the new credentials to the Verification API');
+      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+        'Impossible to assign the new credentials to the Verification API',
+      );
       this.lazyClient.sharedConfig = parametersBackup;
       throw error;
     }

--- a/packages/verification/src/rest/v1/verification-service.ts
+++ b/packages/verification/src/rest/v1/verification-service.ts
@@ -5,6 +5,7 @@ import {
   SinchClientParameters,
   SinchLogger,
   VERIFICATION_HOSTNAME,
+  resolveLogger,
 } from '@sinch/sdk-client';
 import { VerificationStatusApi } from './verification-status';
 import { VerificationsApi } from './verifications';
@@ -48,6 +49,7 @@ export class VerificationService {
    * @param {SinchClientParameters} params - an Object containing the necessary properties to initialize the service
    */
   constructor(params: SinchClientParameters) {
+    params.logger = resolveLogger(params.logger);
     this.lazyClient = new LazyVerificationApiClient(params);
 
     this.verificationStatus = new VerificationStatusApi(this.lazyClient);
@@ -78,7 +80,7 @@ export class VerificationService {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
         'Impossible to assign the new credentials to the Verification API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/verification/src/rest/v1/verification-service.ts
+++ b/packages/verification/src/rest/v1/verification-service.ts
@@ -42,14 +42,16 @@ export class VerificationService {
    * @param {SinchClientParameters} params - an Object containing the necessary properties to initialize the service
    */
   constructor(params: SinchClientParameters) {
-    this.lazyClient = new LazyVerificationApiClient(params);
+    const resolvedParams = resolveClientParameters(params);
+    this.lazyClient = new LazyVerificationApiClient(resolvedParams);
 
     this.verificationStatus = new VerificationStatusApi(this.lazyClient);
     this.verifications = new VerificationsApi(this.lazyClient);
   }
 
   public setApiClientConfig(newParams: SinchClientParameters) {
-    this.lazyClient.sharedConfig = resolveClientParameters(newParams);
+    const resolvedParams = resolveClientParameters(newParams);
+    this.lazyClient.sharedConfig = resolvedParams;
     this.lazyClient.resetApiClient();
   }
 

--- a/packages/verification/tests/rest/v1/verification-api.test.ts
+++ b/packages/verification/tests/rest/v1/verification-api.test.ts
@@ -27,7 +27,7 @@ describe('Verification API', () => {
   });
 
   it('should use the hostname parameter', () => {
-    params.verificationHostname = CUSTOM_HOSTNAME;
+    lazyClient.sharedConfig.verificationHostname = CUSTOM_HOSTNAME;
     verificationApi = new VerificationDomainApi(lazyClient, 'dummy');
     expect(verificationApi.client?.apiClientOptions.hostname).toBe(CUSTOM_HOSTNAME);
   });

--- a/packages/verification/tests/rest/v1/verification-api.test.ts
+++ b/packages/verification/tests/rest/v1/verification-api.test.ts
@@ -55,6 +55,7 @@ describe('Verification API', () => {
     expect(() => verificationApi.setCredentials({ applicationKey: '' }))
       .toThrow('Invalid configuration for the Verification API: "applicationKey" and "applicationSecret"'
         + ' values must be provided');
-    expect(errorSpy).toHaveBeenCalledWith('Impossible to assign the new credentials to the Verification API');
+    expect(errorSpy).toHaveBeenCalledWith('[Sinch SDK][Error] '
+      + 'Impossible to assign the new credentials to the Verification API');
   });
 });

--- a/packages/verification/tests/rest/v1/verification-api.test.ts
+++ b/packages/verification/tests/rest/v1/verification-api.test.ts
@@ -1,4 +1,4 @@
-import { ApiHostname, ApplicationCredentials, SigningRequest } from '@sinch/sdk-client';
+import { ApiHostname, ApplicationCredentials, SigningRequest, resolveClientParameters } from '@sinch/sdk-client';
 import { LazyVerificationApiClient, VerificationDomainApi } from '../../../src';
 
 describe('Verification API', () => {
@@ -14,7 +14,7 @@ describe('Verification API', () => {
       applicationKey: 'APPLICATION_KEY',
       applicationSecret: 'APPLICATION_SECRET',
     };
-    lazyClient = new LazyVerificationApiClient(params);
+    lazyClient = new LazyVerificationApiClient(resolveClientParameters(params));
     errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 

--- a/packages/verification/tests/rest/v1/verification-service.test.ts
+++ b/packages/verification/tests/rest/v1/verification-service.test.ts
@@ -135,7 +135,8 @@ describe('Verification Service', () => {
     expect(() => verificationService.setCredentials({ applicationKey: '' }))
       .toThrow('Invalid configuration for the Verification API: "applicationKey" and "applicationSecret"'
         + ' values must be provided');
-    expect(errorSpy).toHaveBeenCalledWith('Impossible to assign the new credentials to the Verification API');
+    expect(errorSpy).toHaveBeenCalledWith('[Sinch SDK][Error] '
+      + 'Impossible to assign the new credentials to the Verification API');
 
     // Then
     expect(verificationService.lazyClient.sharedConfig.applicationKey).toBe('APPLICATION_KEY');

--- a/packages/verification/tests/rest/v1/verification-status/verification-status-api.test.ts
+++ b/packages/verification/tests/rest/v1/verification-status/verification-status-api.test.ts
@@ -1,4 +1,4 @@
-import { ApiClientOptions, SigningRequest } from '@sinch/sdk-client';
+import { ApiClientOptions, SigningRequest, resolveClientParameters }from '@sinch/sdk-client';
 import {
   LazyVerificationApiClient,
   Verification,
@@ -17,7 +17,7 @@ describe('VerificationStatusApi', () => {
       projectId: 'Test_ProjectId',
       requestPlugins: [new SigningRequest('keyId', 'keySecret')],
     };
-    const lazyClient = new LazyVerificationApiClient(apiClientOptions);
+    const lazyClient = new LazyVerificationApiClient(resolveClientParameters(apiClientOptions));
     verificationStatusApi = new VerificationStatusApi(lazyClient);
   });
 

--- a/packages/verification/tests/rest/v1/verifications/verifications-api.test.ts
+++ b/packages/verification/tests/rest/v1/verifications/verifications-api.test.ts
@@ -1,4 +1,4 @@
-import { ApiClientOptions, SigningRequest } from '@sinch/sdk-client';
+import { ApiClientOptions, SigningRequest, resolveClientParameters }from '@sinch/sdk-client';
 import {
   LazyVerificationApiClient,
   Verification,
@@ -30,7 +30,7 @@ describe('VerificationsApi', () => {
       projectId: 'Test_ProjectId',
       requestPlugins: [new SigningRequest('keyId', 'keySecret')],
     };
-    const lazyClient = new LazyVerificationApiClient(apiClientOptions);
+    const lazyClient = new LazyVerificationApiClient(resolveClientParameters(apiClientOptions));
     verificationsApi = new VerificationsApi(lazyClient);
   });
 

--- a/packages/voice/src/models/v1/helper.ts
+++ b/packages/voice/src/models/v1/helper.ts
@@ -165,10 +165,6 @@ export const svamlInstructionHelper = {
     };
   },
   buildSendDtmf: (dtmfValue: string): SvamlInstructionSendDtmf => {
-    const dtmfRegex = /^[0-9#w]+$/;
-    if(!dtmfRegex.test(dtmfValue)) {
-      console.error(`The DTMF value '${dtmfValue}' is incorrect. Valid characters are: 0-9, #, and w.`);
-    }
     return {
       name: 'sendDtmf',
       value: dtmfValue,

--- a/packages/voice/src/rest/v1/callbacks/callbacks-webhook.ts
+++ b/packages/voice/src/rest/v1/callbacks/callbacks-webhook.ts
@@ -64,8 +64,7 @@ export class VoiceCallbackWebhooks implements CallbackProcessor<VoiceCallbackEve
           throw new Error(`Unknown Voice event type: ${eventBody.event}`);
       }
     }
-    console.log(eventBody);
-    throw new Error('Unknown Voice event');
+    throw new Error(`Unknown Voice event: ${JSON.stringify(eventBody)}`);
   }
 
   /**

--- a/packages/voice/src/rest/v1/voice-domain-api.ts
+++ b/packages/voice/src/rest/v1/voice-domain-api.ts
@@ -2,6 +2,7 @@ import {
   Api,
   ApiClient,
   ApplicationCredentials,
+  SinchLogger,
   VoiceRegion,
 } from '@sinch/sdk-client';
 import { LazyVoiceApiClient, LazyVoiceApplicationManagementApiClient } from './voice-service';
@@ -62,7 +63,9 @@ export class VoiceDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      console.error('Impossible to assign the new credentials to the Voice API');
+      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+        'Impossible to assign the new credentials to the Voice API',
+      );
       this.lazyClient.sharedConfig = parametersBackup;
       throw error;
     }

--- a/packages/voice/src/rest/v1/voice-domain-api.ts
+++ b/packages/voice/src/rest/v1/voice-domain-api.ts
@@ -2,9 +2,7 @@ import {
   Api,
   ApiClient,
   ApplicationCredentials,
-  SinchLogger,
   VoiceRegion,
-  resolveLogger,
 } from '@sinch/sdk-client';
 import { LazyVoiceApiClient, LazyVoiceApplicationManagementApiClient } from './voice-service';
 
@@ -64,7 +62,7 @@ export class VoiceDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
+      this.lazyClient.sharedConfig.logger!.error(
         'Impossible to assign the new credentials to the Voice API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/voice/src/rest/v1/voice-domain-api.ts
+++ b/packages/voice/src/rest/v1/voice-domain-api.ts
@@ -4,6 +4,7 @@ import {
   ApplicationCredentials,
   SinchLogger,
   VoiceRegion,
+  resolveLogger,
 } from '@sinch/sdk-client';
 import { LazyVoiceApiClient, LazyVoiceApplicationManagementApiClient } from './voice-service';
 
@@ -63,7 +64,7 @@ export class VoiceDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      new SinchLogger(this.lazyClient.sharedConfig.logger ?? console).error(
+      new SinchLogger(resolveLogger(this.lazyClient.sharedConfig.logger)).error(
         'Impossible to assign the new credentials to the Voice API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/voice/src/rest/v1/voice-domain-api.ts
+++ b/packages/voice/src/rest/v1/voice-domain-api.ts
@@ -62,7 +62,7 @@ export class VoiceDomainApi implements Api {
     try {
       this.lazyClient.getApiClient();
     } catch (error) {
-      this.lazyClient.sharedConfig.logger!.error(
+      this.lazyClient.sharedConfig.logger.error(
         'Impossible to assign the new credentials to the Voice API',
       );
       this.lazyClient.sharedConfig = parametersBackup;

--- a/packages/voice/src/rest/v1/voice-service.ts
+++ b/packages/voice/src/rest/v1/voice-service.ts
@@ -5,6 +5,7 @@ import {
   ConversationRegion,
   formatRegionalizedHostname,
   SinchClientParameters,
+  SinchLogger,
   SupportedVoiceRegion,
   VOICE_APPLICATION_MANAGEMENT_HOSTNAME,
   VOICE_HOSTNAME,
@@ -23,7 +24,9 @@ export class LazyVoiceApiClient {
     if (!this.apiFetchClient) {
       const region = this.sharedConfig.voiceRegion ?? VoiceRegion.DEFAULT;
       if(!Object.values(SupportedVoiceRegion).includes(region as SupportedVoiceRegion)) {
-        console.warn(`The region "${region}" is not known as a supported region for the Voice API`);
+        new SinchLogger(this.sharedConfig.logger ?? console).warn(
+          `The region "${region}" is not known as a supported region for the Voice API`,
+        );
       }
       const apiClientOptions = buildApplicationSignedApiClientOptions(this.sharedConfig, 'Voice');
       this.apiFetchClient = new ApiFetchClient(apiClientOptions);
@@ -157,7 +160,9 @@ export class VoiceService {
       this.lazyVoiceClient.getApiClient();
       this.lazyVoiceAppMgmtClient.getApiClient();
     } catch (error) {
-      console.error('Impossible to assign the new credentials to the Voice API');
+      new SinchLogger(this.lazyVoiceClient.sharedConfig.logger ?? console).error(
+        'Impossible to assign the new credentials to the Voice API',
+      );
       this.lazyVoiceClient.sharedConfig = parametersBackup;
       this.lazyVoiceAppMgmtClient.sharedConfig = parametersAppMgmtBackup;
       throw error;

--- a/packages/voice/src/rest/v1/voice-service.ts
+++ b/packages/voice/src/rest/v1/voice-service.ts
@@ -80,11 +80,11 @@ export class VoiceService {
    * @param {SinchClientParameters} params - an Object containing the necessary properties to initialize the service
    */
   constructor(params: SinchClientParameters) {
-    const sharedConfig = resolveClientParameters(params);
-    const sharedVoiceClient = new LazyVoiceApiClient(sharedConfig);
+    const resolvedParams = resolveClientParameters(params);
+    const sharedVoiceClient = new LazyVoiceApiClient(resolvedParams);
     this.lazyVoiceClient = sharedVoiceClient;
 
-    const sharedVoiceAppMgmtClient = new LazyVoiceApplicationManagementApiClient(sharedConfig);
+    const sharedVoiceAppMgmtClient = new LazyVoiceApplicationManagementApiClient(resolvedParams);
     this.lazyVoiceAppMgmtClient = sharedVoiceAppMgmtClient;
 
     this.applications = new ApplicationsApi(sharedVoiceAppMgmtClient);

--- a/packages/voice/src/rest/v1/voice-service.ts
+++ b/packages/voice/src/rest/v1/voice-service.ts
@@ -7,6 +7,7 @@ import {
   SinchClientParameters,
   SinchLogger,
   SupportedVoiceRegion,
+  resolveLogger,
   VOICE_APPLICATION_MANAGEMENT_HOSTNAME,
   VOICE_HOSTNAME,
   VoiceRegion,
@@ -24,7 +25,7 @@ export class LazyVoiceApiClient {
     if (!this.apiFetchClient) {
       const region = this.sharedConfig.voiceRegion ?? VoiceRegion.DEFAULT;
       if(!Object.values(SupportedVoiceRegion).includes(region as SupportedVoiceRegion)) {
-        new SinchLogger(this.sharedConfig.logger ?? console).warn(
+        new SinchLogger(resolveLogger(this.sharedConfig.logger)).warn(
           `The region "${region}" is not known as a supported region for the Voice API`,
         );
       }
@@ -93,6 +94,7 @@ export class VoiceService {
    * @param {SinchClientParameters} params - an Object containing the necessary properties to initialize the service
    */
   constructor(params: SinchClientParameters) {
+    params.logger = resolveLogger(params.logger);
     const sharedVoiceClient = new LazyVoiceApiClient(params);
     this.lazyVoiceClient = sharedVoiceClient;
 
@@ -160,7 +162,7 @@ export class VoiceService {
       this.lazyVoiceClient.getApiClient();
       this.lazyVoiceAppMgmtClient.getApiClient();
     } catch (error) {
-      new SinchLogger(this.lazyVoiceClient.sharedConfig.logger ?? console).error(
+      new SinchLogger(resolveLogger(this.lazyVoiceClient.sharedConfig.logger)).error(
         'Impossible to assign the new credentials to the Voice API',
       );
       this.lazyVoiceClient.sharedConfig = parametersBackup;

--- a/packages/voice/src/rest/v1/voice-service.ts
+++ b/packages/voice/src/rest/v1/voice-service.ts
@@ -5,7 +5,6 @@ import {
   ConversationRegion,
   formatRegionalizedHostname,
   SinchClientParameters,
-  SinchLogger,
   SupportedVoiceRegion,
   resolveLogger,
   VOICE_APPLICATION_MANAGEMENT_HOSTNAME,
@@ -25,7 +24,7 @@ export class LazyVoiceApiClient {
     if (!this.apiFetchClient) {
       const region = this.sharedConfig.voiceRegion ?? VoiceRegion.DEFAULT;
       if(!Object.values(SupportedVoiceRegion).includes(region as SupportedVoiceRegion)) {
-        new SinchLogger(resolveLogger(this.sharedConfig.logger)).warn(
+        this.sharedConfig.logger!.warn(
           `The region "${region}" is not known as a supported region for the Voice API`,
         );
       }
@@ -162,7 +161,7 @@ export class VoiceService {
       this.lazyVoiceClient.getApiClient();
       this.lazyVoiceAppMgmtClient.getApiClient();
     } catch (error) {
-      new SinchLogger(resolveLogger(this.lazyVoiceClient.sharedConfig.logger)).error(
+      this.lazyVoiceClient.sharedConfig.logger!.error(
         'Impossible to assign the new credentials to the Voice API',
       );
       this.lazyVoiceClient.sharedConfig = parametersBackup;

--- a/packages/voice/src/rest/v1/voice-service.ts
+++ b/packages/voice/src/rest/v1/voice-service.ts
@@ -6,7 +6,8 @@ import {
   formatRegionalizedHostname,
   SinchClientParameters,
   SupportedVoiceRegion,
-  resolveLogger,
+  LazyApiClient,
+  resolveClientParameters,
   VOICE_APPLICATION_MANAGEMENT_HOSTNAME,
   VOICE_HOSTNAME,
   VoiceRegion,
@@ -16,15 +17,12 @@ import { ConferencesApi } from './conferences';
 import { CallsApi } from './calls';
 import { CalloutsApi } from './callouts';
 
-export class LazyVoiceApiClient {
-  apiFetchClient?: ApiFetchClient;
-  constructor(public sharedConfig: SinchClientParameters) {}
-
+export class LazyVoiceApiClient extends LazyApiClient {
   public getApiClient(): ApiFetchClient {
     if (!this.apiFetchClient) {
       const region = this.sharedConfig.voiceRegion ?? VoiceRegion.DEFAULT;
       if(!Object.values(SupportedVoiceRegion).includes(region as SupportedVoiceRegion)) {
-        this.sharedConfig.logger!.warn(
+        this.sharedConfig.logger.warn(
           `The region "${region}" is not known as a supported region for the Voice API`,
         );
       }
@@ -35,10 +33,6 @@ export class LazyVoiceApiClient {
     return this.apiFetchClient;
   }
 
-  public resetApiClient() {
-    this.apiFetchClient = undefined;
-  }
-
   private buildHostname(region: ConversationRegion) {
     const formattedRegion = region === VoiceRegion.DEFAULT ? region : `-${region}`;
     return this.sharedConfig.voiceHostname ?? formatRegionalizedHostname(VOICE_HOSTNAME, formattedRegion);
@@ -46,10 +40,7 @@ export class LazyVoiceApiClient {
 
 }
 
-export class LazyVoiceApplicationManagementApiClient {
-  apiFetchClient?: ApiFetchClient;
-  constructor(public sharedConfig: SinchClientParameters) {}
-
+export class LazyVoiceApplicationManagementApiClient extends LazyApiClient {
   public getApiClient(): ApiFetchClient {
     if (!this.apiFetchClient) {
       const apiClientOptions = buildApplicationSignedApiClientOptions(this.sharedConfig, 'Voice');
@@ -58,10 +49,6 @@ export class LazyVoiceApplicationManagementApiClient {
         = this.sharedConfig.voiceApplicationManagementHostname ?? VOICE_APPLICATION_MANAGEMENT_HOSTNAME;
     }
     return this.apiFetchClient;
-  }
-
-  public resetApiClient() {
-    this.apiFetchClient = undefined;
   }
 }
 
@@ -93,11 +80,11 @@ export class VoiceService {
    * @param {SinchClientParameters} params - an Object containing the necessary properties to initialize the service
    */
   constructor(params: SinchClientParameters) {
-    params.logger = resolveLogger(params.logger);
-    const sharedVoiceClient = new LazyVoiceApiClient(params);
+    const sharedConfig = resolveClientParameters(params);
+    const sharedVoiceClient = new LazyVoiceApiClient(sharedConfig);
     this.lazyVoiceClient = sharedVoiceClient;
 
-    const sharedVoiceAppMgmtClient = new LazyVoiceApplicationManagementApiClient(params);
+    const sharedVoiceAppMgmtClient = new LazyVoiceApplicationManagementApiClient(sharedConfig);
     this.lazyVoiceAppMgmtClient = sharedVoiceAppMgmtClient;
 
     this.applications = new ApplicationsApi(sharedVoiceAppMgmtClient);
@@ -107,9 +94,10 @@ export class VoiceService {
   }
 
   public setApiClientConfig(newParams: SinchClientParameters) {
-    this.lazyVoiceClient.sharedConfig = newParams;
+    const resolvedParams = resolveClientParameters(newParams);
+    this.lazyVoiceClient.sharedConfig = resolvedParams;
     this.lazyVoiceClient.resetApiClient();
-    this.lazyVoiceAppMgmtClient.sharedConfig = newParams;
+    this.lazyVoiceAppMgmtClient.sharedConfig = resolvedParams;
     this.lazyVoiceAppMgmtClient.resetApiClient();
   }
 
@@ -161,7 +149,7 @@ export class VoiceService {
       this.lazyVoiceClient.getApiClient();
       this.lazyVoiceAppMgmtClient.getApiClient();
     } catch (error) {
-      this.lazyVoiceClient.sharedConfig.logger!.error(
+      this.lazyVoiceClient.sharedConfig.logger.error(
         'Impossible to assign the new credentials to the Voice API',
       );
       this.lazyVoiceClient.sharedConfig = parametersBackup;

--- a/packages/voice/tests/rest/v1/applications/applications-api.test.ts
+++ b/packages/voice/tests/rest/v1/applications/applications-api.test.ts
@@ -1,4 +1,4 @@
-import { ApiClientOptions, SigningRequest } from '@sinch/sdk-client';
+import { ApiClientOptions, SigningRequest, resolveClientParameters }from '@sinch/sdk-client';
 import {
   ApplicationsApi,
   ApplicationsApiFixture,
@@ -16,7 +16,7 @@ describe('ApplicationsApi', () => {
     apiClientOptions = {
       requestPlugins: [new SigningRequest('keyId', 'keySecret')],
     };
-    const lazyClient = new LazyVoiceApplicationManagementApiClient(apiClientOptions);
+    const lazyClient = new LazyVoiceApplicationManagementApiClient(resolveClientParameters(apiClientOptions));
     applicationsApi = new ApplicationsApi(lazyClient);
   });
 

--- a/packages/voice/tests/rest/v1/callouts/callouts-api.test.ts
+++ b/packages/voice/tests/rest/v1/callouts/callouts-api.test.ts
@@ -1,4 +1,4 @@
-import { ApiClientOptions, SigningRequest } from '@sinch/sdk-client';
+import { ApiClientOptions, SigningRequest, resolveClientParameters }from '@sinch/sdk-client';
 import {
   CalloutsApi,
   CalloutsApiFixture,
@@ -16,7 +16,7 @@ describe('CalloutsApi', () => {
     apiClientOptions = {
       requestPlugins: [new SigningRequest('keyId', 'keySecret')],
     };
-    const lazyClient = new LazyVoiceApiClient(apiClientOptions);
+    const lazyClient = new LazyVoiceApiClient(resolveClientParameters(apiClientOptions));
     calloutsApi = new CalloutsApi(lazyClient);
   });
 

--- a/packages/voice/tests/rest/v1/calls/calls-api.test.ts
+++ b/packages/voice/tests/rest/v1/calls/calls-api.test.ts
@@ -1,4 +1,4 @@
-import { ApiClientOptions, SigningRequest } from '@sinch/sdk-client';
+import { ApiClientOptions, SigningRequest, resolveClientParameters }from '@sinch/sdk-client';
 import {
   CallsApi,
   CallsApiFixture,
@@ -16,7 +16,7 @@ describe('CallsApi', () => {
     apiClientOptions = {
       requestPlugins: [new SigningRequest('keyId', 'keySecret')],
     };
-    const lazyClient = new LazyVoiceApiClient(apiClientOptions);
+    const lazyClient = new LazyVoiceApiClient(resolveClientParameters(apiClientOptions));
     callsApi = new CallsApi(lazyClient);
   });
 

--- a/packages/voice/tests/rest/v1/conferences/conferences-api.test.ts
+++ b/packages/voice/tests/rest/v1/conferences/conferences-api.test.ts
@@ -1,4 +1,4 @@
-import { ApiClientOptions, SigningRequest } from '@sinch/sdk-client';
+import { ApiClientOptions, SigningRequest, resolveClientParameters }from '@sinch/sdk-client';
 import {
   ConferencesApi,
   ConferencesApiFixture,
@@ -17,7 +17,7 @@ describe('ConferencesApi', () => {
     apiClientOptions = {
       requestPlugins: [new SigningRequest('keyId', 'keySecret')],
     };
-    const lazyClient = new LazyVoiceApiClient(apiClientOptions);
+    const lazyClient = new LazyVoiceApiClient(resolveClientParameters(apiClientOptions));
     conferencesApi = new ConferencesApi(lazyClient);
   });
 

--- a/packages/voice/tests/rest/v1/voice-domain-api.test.ts
+++ b/packages/voice/tests/rest/v1/voice-domain-api.test.ts
@@ -1,4 +1,4 @@
-import { ApiHostname, ApplicationCredentials, SigningRequest, VoiceRegion } from '@sinch/sdk-client';
+import { ApiHostname, ApplicationCredentials, SigningRequest, VoiceRegion, resolveClientParameters } from '@sinch/sdk-client';
 import { LazyVoiceApiClient, LazyVoiceApplicationManagementApiClient, VoiceDomainApi } from '../../../src';
 
 
@@ -20,8 +20,8 @@ describe('Voice API', () => {
     };
     warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    lazyVoiceClient = new LazyVoiceApiClient(params);
-    lazyVoiceApplicationMgmtClient = new LazyVoiceApplicationManagementApiClient(params);
+    lazyVoiceClient = new LazyVoiceApiClient(resolveClientParameters(params));
+    lazyVoiceApplicationMgmtClient = new LazyVoiceApplicationManagementApiClient(resolveClientParameters(params));
   });
 
   afterEach(() => {

--- a/packages/voice/tests/rest/v1/voice-domain-api.test.ts
+++ b/packages/voice/tests/rest/v1/voice-domain-api.test.ts
@@ -37,13 +37,13 @@ describe('Voice API', () => {
   });
 
   it('should change the URL when specifying a different region', () => {
-    params.voiceRegion = VoiceRegion.UNITED_STATES;
+    lazyVoiceClient.sharedConfig.voiceRegion = VoiceRegion.UNITED_STATES;
     voiceApi = new VoiceDomainApi(lazyVoiceClient, 'dummy');
     expect(voiceApi.client?.apiClientOptions.hostname).toBe('https://calling-use1.api.sinch.com');
   });
 
   it('should log a warning when using an unsupported region', async () => {
-    params.voiceRegion = 'bzh';
+    lazyVoiceClient.sharedConfig.voiceRegion = 'bzh';
     voiceApi = new VoiceDomainApi(lazyVoiceClient, 'dummy');
     expect(voiceApi.client?.apiClientOptions.hostname).toBe('https://calling-bzh.api.sinch.com');
     expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] '
@@ -51,7 +51,7 @@ describe('Voice API', () => {
   });
 
   it('should use the hostname parameter but not for voice application management', () => {
-    params.voiceHostname = CUSTOM_HOSTNAME;
+    lazyVoiceClient.sharedConfig.voiceHostname = CUSTOM_HOSTNAME;
     voiceApi = new VoiceDomainApi(lazyVoiceClient, 'dummy');
     voiceApplicationApi = new VoiceDomainApi(lazyVoiceApplicationMgmtClient, 'dummy');
     expect(voiceApi.client?.apiClientOptions.hostname).toBe(CUSTOM_HOSTNAME);
@@ -59,7 +59,7 @@ describe('Voice API', () => {
   });
 
   it('should use the hostname parameter for voice application management only', () => {
-    params.voiceApplicationManagementHostname = CUSTOM_HOSTNAME_APPLICATIONS;
+    lazyVoiceApplicationMgmtClient.sharedConfig.voiceApplicationManagementHostname = CUSTOM_HOSTNAME_APPLICATIONS;
     voiceApi = new VoiceDomainApi(lazyVoiceClient, 'dummy');
     voiceApplicationApi = new VoiceDomainApi(lazyVoiceApplicationMgmtClient, 'dummy');
     expect(voiceApi.client?.apiClientOptions.hostname).toBe('https://calling.api.sinch.com');
@@ -67,8 +67,8 @@ describe('Voice API', () => {
   });
 
   it('should use the hostname parameter for the 2 different domains', () => {
-    params.voiceHostname = CUSTOM_HOSTNAME;
-    params.voiceApplicationManagementHostname = CUSTOM_HOSTNAME_APPLICATIONS;
+    lazyVoiceClient.sharedConfig.voiceHostname = CUSTOM_HOSTNAME;
+    lazyVoiceApplicationMgmtClient.sharedConfig.voiceApplicationManagementHostname = CUSTOM_HOSTNAME_APPLICATIONS;
     voiceApi = new VoiceDomainApi(lazyVoiceClient, 'dummy');
     voiceApplicationApi = new VoiceDomainApi(lazyVoiceApplicationMgmtClient, 'dummy');
     expect(voiceApi.client?.apiClientOptions.hostname).toBe(CUSTOM_HOSTNAME);

--- a/packages/voice/tests/rest/v1/voice-domain-api.test.ts
+++ b/packages/voice/tests/rest/v1/voice-domain-api.test.ts
@@ -46,8 +46,8 @@ describe('Voice API', () => {
     params.voiceRegion = 'bzh';
     voiceApi = new VoiceDomainApi(lazyVoiceClient, 'dummy');
     expect(voiceApi.client?.apiClientOptions.hostname).toBe('https://calling-bzh.api.sinch.com');
-    expect(warnSpy).toHaveBeenCalledWith(
-      'The region "bzh" is not known as a supported region for the Voice API');
+    expect(warnSpy).toHaveBeenCalledWith('[Sinch SDK][Warn] '
+      + 'The region "bzh" is not known as a supported region for the Voice API');
   });
 
   it('should use the hostname parameter but not for voice application management', () => {
@@ -100,7 +100,8 @@ describe('Voice API', () => {
     expect(() => voiceApi.setCredentials({ applicationKey: '' }))
       .toThrow('Invalid configuration for the Voice API: "applicationKey" and "applicationSecret"'
         + ' values must be provided');
-    expect(errorSpy).toHaveBeenCalledWith('Impossible to assign the new credentials to the Voice API');
+    expect(errorSpy).toHaveBeenCalledWith('[Sinch SDK][Error] '
+      + 'Impossible to assign the new credentials to the Voice API');
   });
 
   it('should update the region', () => {

--- a/packages/voice/tests/rest/v1/voice-service.test.ts
+++ b/packages/voice/tests/rest/v1/voice-service.test.ts
@@ -185,7 +185,8 @@ describe('Voice Service', () => {
     expect(() => voiceService.setCredentials({ applicationKey: '' }))
       .toThrow('Invalid configuration for the Voice API: "applicationKey" and "applicationSecret"'
         + ' values must be provided');
-    expect(errorSpy).toHaveBeenCalledWith('Impossible to assign the new credentials to the Voice API');
+    expect(errorSpy).toHaveBeenCalledWith('[Sinch SDK][Error] '
+      + 'Impossible to assign the new credentials to the Voice API');
 
     // Then
     expect(voiceService.lazyVoiceClient.sharedConfig.applicationKey).toBe('APPLICATION_KEY');


### PR DESCRIPTION
**How to enable debug logs:**
```
import winston from 'winston';
const winstonLogger = winston.createLogger({
  level: 'debug',
  transports: [new winston.transports.Console()],
  format: winston.format.logstash(),
});

new SinchClient({ projectId, keyId, keySecret, logger:  winstonLogger});
```

**Debug logs:**
```
[Sinch SDK][Debug][AvailableRegionsApi][ListAvailableRegions][401]
HTTP method: GET
URL: https://numbers.api.sinch.com/v1/projects/37b62a7b-0177-429a-bb0b-e10f848de0b8/availableRegions?types=LOCAL&types=MOBILE
Response Headers:  Headers {
  [Symbol(map)]: [Object: null prototype] {
    'www-authenticate': [
      'Bearer error="invalid_token", error_description="Jwt expired at 2023-10-02T14:57:08Z", error_uri="https://tools.ietf.org/html/rfc6750#section-3.1"'
    ],
    'cache-control': [ 'no-cache, no-store, max-age=0, must-revalidate' ],
    pragma: [ 'no-cache' ],
    expires: [ '0' ],
    'x-content-type-options': [ 'nosniff' ],
    'strict-transport-security': [ 'max-age=31536000 ; includeSubDomains' ],
    'x-frame-options': [ 'DENY' ],
    'x-xss-protection': [ '0' ],
    'referrer-policy': [ 'no-referrer' ],
    'x-envoy-upstream-service-time': [ '2' ],
    date: [ 'Tue, 02 Dec 2025 22:25:38 GMT' ],
    server: [ 'istio-envoy' ],
    connection: [ 'close' ],
    'content-length': [ '0' ]
  }
}

```